### PR TITLE
 🐛 add jinja2 import to generate html table

### DIFF
--- a/clients/python/requirements/test.txt
+++ b/clients/python/requirements/test.txt
@@ -3,6 +3,7 @@
 black
 ipykernel
 ipython
+jinja2
 matplotlib
 packaging
 pandas


### PR DESCRIPTION
<!-- Common title prefixes/annotations:
PREFIX:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  ♻️     Refactor code.
  🚑️    Critical hotfix.
  ⚗️     Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🗑️    Deprecate code that needs to be cleaned up.
  ⚰️     Remove dead code.
  🔥    Remove code or files.
  🔨    Add or update development scripts.

or from https://gitmoji.dev/
-->

## What do these changes do?
Turns out `jinja2` is required to generate the html table on e2e ci. I think I managed to remove that one when doing the clean up of the imports/installs. Hence, I add it again here. 
<!-- Explain REVIEWERS what is this PR about -->


## Related issue/s

<!-- Enumerate REVIEWERS other issues

e.g.

- #26 : node_ports should have retry policies when upload/download fails  (FIXED)
- ITISFoundation/osparc-issues#304: (Part 2) Prep2Go: creating features to support complex S4L scripts (IMPLEMENTED)

-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->
