### PR TITLE
✨ Create iterator for paginated server methods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,7 +65,7 @@ target/
 .ipynb_checkpoints
 
 # vscode config
-.vscode/settings.json
+.vscode/*
 
 # docs output
 site

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,3 +40,8 @@ repos:
         # pre-commit's default_language_version, see
         # https://pre-commit.com/#top_level-default_language_version
         # language_version: python3.11
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    # Ruff version.
+    rev: v0.0.282
+    hooks:
+      - id: ruff

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,6 +25,12 @@ repos:
           - "[pin];[donotremove]"
         files: .*[.]ipynb$
         types: ["file"]
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    # Ruff version.
+    rev: v0.0.282
+    hooks:
+      - id: ruff
+        args: [ --fix, --exit-non-zero-on-fix ]
   - repo: https://github.com/pycqa/isort
     rev: 5.12.0
     hooks:
@@ -40,8 +46,3 @@ repos:
         # pre-commit's default_language_version, see
         # https://pre-commit.com/#top_level-default_language_version
         # language_version: python3.11
-  - repo: https://github.com/astral-sh/ruff-pre-commit
-    # Ruff version.
-    rev: v0.0.282
-    hooks:
-      - id: ruff

--- a/clients/python/client/osparc/__init__.py
+++ b/clients/python/client/osparc/__init__.py
@@ -1,5 +1,5 @@
 """
-0.5.0 osparc client
+0.6.0 osparc client
 """
 from typing import Tuple
 
@@ -39,7 +39,6 @@ from osparc_client import RunningState as TaskStates
 from osparc_client import (  # APIs; API client; models
     Solver,
     SolverPort,
-    SolversApi,
     StudiesApi,
     Study,
     StudyPort,
@@ -51,6 +50,7 @@ from osparc_client import (  # APIs; API client; models
 )
 
 from ._info import openapi
+from ._solvers_api import SolversApi
 
 __all__: Tuple[str, ...] = (
     # imports from osparc_client

--- a/clients/python/client/osparc/_solvers_api.py
+++ b/clients/python/client/osparc/_solvers_api.py
@@ -34,16 +34,17 @@ class SolversApi(_SolversApi):
             offset (int, optional): the offset of the first element to return
 
         Returns:
-            Tuple[Iterator[Job], int]: An iterator whose elements are the Jobs submitted to the solver and the total number of jobs the iterator can yield
+            Tuple[Iterator[Job], int]: An iterator whose elements are the Jobs submitted to the solver and the total number of jobs the iterator can yield (its "length")
         """
         pagination_method = lambda limit, offset: super(SolversApi, self).get_jobs_page(
             solver_key=solver_key, version=version, limit=limit, offset=offset
         )
         page: LimitOffsetPageJob = pagination_method(limit, 0)
+        assert offset >= 0, "The offset must be a non-negative integer"
         assert isinstance(page.total, int)
         return (
             _pagination_to_iterator(
                 pagination_method=pagination_method, limit=limit, offset=offset
             ),
-            page.total,
+            page.total - offset,
         )

--- a/clients/python/client/osparc/_solvers_api.py
+++ b/clients/python/client/osparc/_solvers_api.py
@@ -1,12 +1,15 @@
-from typing import Any, Iterator
+from typing import Any, Iterator, List
 
 from osparc_client import SolversApi as _SolversApi
 
 from . import ApiClient, Job
+from ._utils import _pagination_to_iterator
 
 
 class SolversApi:
     """Class for interacting with solvers"""
+
+    _wrapped_methods: List[str] = ["get_jobs"]
 
     def __init__(self, api_client: ApiClient):
         """Construct object
@@ -27,8 +30,13 @@ class SolversApi:
         Yields:
             Iterator[Job]: An iterator whose elements are the Jobs submitted to the solver
         """
-        limit: int = 20
-        offset: int = 0
+        pagination_method = lambda limit, offset: self._solvers_api.get_jobs_page(
+            solver_key=solver_key, version=version, limit=limit, offset=offset
+        )
+        return _pagination_to_iterator(pagination_method=pagination_method)
 
-    def __getattr__(self, __name: str) -> Any:
-        return getattr(self._solvers_api, __name)
+    def __getattr__(self, name: str) -> Any:
+        if name in self._wrapped_methods:
+            return getattr(self, name)
+        else:
+            return getattr(self._solvers_api, name)

--- a/clients/python/client/osparc/_solvers_api.py
+++ b/clients/python/client/osparc/_solvers_api.py
@@ -1,9 +1,8 @@
-from typing import Any, Iterator, List, Optional, Tuple
+from typing import Optional
 
-from osparc_client import LimitOffsetPageJob
 from osparc_client import SolversApi as _SolversApi
 
-from . import ApiClient, Job
+from . import ApiClient
 from ._utils import PaginationIterator
 
 
@@ -25,7 +24,8 @@ class SolversApi(_SolversApi):
     def get_jobs(
         self, solver_key: str, version: str, limit: int = 20, offset: int = 0
     ) -> PaginationIterator:
-        """Returns an iterator through which one can iterate over all Jobs submitted to the solver
+        """Returns an iterator through which one can iterate over
+        all Jobs submitted to the solver
 
         Args:
             solver_key (str): The solver key
@@ -34,9 +34,14 @@ class SolversApi(_SolversApi):
             offset (int, optional): the offset of the first element to return
 
         Returns:
-            PaginationIterator: An iterator whose elements are the Jobs submitted to the solver and the total number of jobs the iterator can yield (its "length")
+            PaginationIterator: An iterator whose elements are the Jobs submitted
+            to the solver and the total number of jobs the iterator can yield
+            (its "length")
         """
-        pagination_method = lambda limit, offset: super(SolversApi, self).get_jobs_page(
-            solver_key=solver_key, version=version, limit=limit, offset=offset
-        )
+
+        def pagination_method(limit, offset):
+            return super(SolversApi, self).get_jobs_page(
+                solver_key=solver_key, version=version, limit=limit, offset=offset
+            )
+
         return PaginationIterator(pagination_method, limit, offset)

--- a/clients/python/client/osparc/_solvers_api.py
+++ b/clients/python/client/osparc/_solvers_api.py
@@ -17,9 +17,11 @@ class SolversApi(_SolversApi):
         """
         super().__init__(api_client)
 
-    def get_jobs_page(
-        self, solver_key: str, version: str, limit: int = 20
-    ) -> Iterator[Job]:
+    def get_jobs_page(self, solver_key: str, version: str) -> None:
+        """Method only for internal use"""
+        raise NotImplementedError("This method is only for internal use")
+
+    def get_jobs(self, solver_key: str, version: str, limit: int = 20) -> Iterator[Job]:
         """Returns an iterator through which one can iterate over all Jobs submitted to the solver
 
         Args:

--- a/clients/python/client/osparc/_solvers_api.py
+++ b/clients/python/client/osparc/_solvers_api.py
@@ -3,7 +3,7 @@ from typing import Optional
 from osparc_client import SolversApi as _SolversApi
 
 from . import ApiClient
-from ._utils import PaginationIterator
+from ._utils import PaginationGenerator
 
 
 class SolversApi(_SolversApi):
@@ -23,7 +23,7 @@ class SolversApi(_SolversApi):
 
     def get_jobs(
         self, solver_key: str, version: str, limit: int = 20, offset: int = 0
-    ) -> PaginationIterator:
+    ) -> PaginationGenerator:
         """Returns an iterator through which one can iterate over
         all Jobs submitted to the solver
 
@@ -34,7 +34,7 @@ class SolversApi(_SolversApi):
             offset (int, optional): the offset of the first element to return
 
         Returns:
-            PaginationIterator: An iterator whose elements are the Jobs submitted
+            PaginationGenerator: A generator whose elements are the Jobs submitted
             to the solver and the total number of jobs the iterator can yield
             (its "length")
         """
@@ -44,4 +44,4 @@ class SolversApi(_SolversApi):
                 solver_key=solver_key, version=version, limit=limit, offset=offset
             )
 
-        return PaginationIterator(pagination_method, limit, offset)
+        return PaginationGenerator(pagination_method, limit, offset)

--- a/clients/python/client/osparc/_solvers_api.py
+++ b/clients/python/client/osparc/_solvers_api.py
@@ -4,7 +4,7 @@ from osparc_client import LimitOffsetPageJob
 from osparc_client import SolversApi as _SolversApi
 
 from . import ApiClient, Job
-from ._utils import _pagination_to_iterator
+from ._utils import PaginationIterator
 
 
 class SolversApi(_SolversApi):
@@ -24,7 +24,7 @@ class SolversApi(_SolversApi):
 
     def get_jobs(
         self, solver_key: str, version: str, limit: int = 20, offset: int = 0
-    ) -> Tuple[Iterator[Job], int]:
+    ) -> PaginationIterator:
         """Returns an iterator through which one can iterate over all Jobs submitted to the solver
 
         Args:
@@ -34,17 +34,9 @@ class SolversApi(_SolversApi):
             offset (int, optional): the offset of the first element to return
 
         Returns:
-            Tuple[Iterator[Job], int]: An iterator whose elements are the Jobs submitted to the solver and the total number of jobs the iterator can yield (its "length")
+            PaginationIterator: An iterator whose elements are the Jobs submitted to the solver and the total number of jobs the iterator can yield (its "length")
         """
         pagination_method = lambda limit, offset: super(SolversApi, self).get_jobs_page(
             solver_key=solver_key, version=version, limit=limit, offset=offset
         )
-        page: LimitOffsetPageJob = pagination_method(limit, 0)
-        assert offset >= 0, "The offset must be a non-negative integer"
-        assert isinstance(page.total, int)
-        return (
-            _pagination_to_iterator(
-                pagination_method=pagination_method, limit=limit, offset=offset
-            ),
-            page.total - offset,
-        )
+        return PaginationIterator(pagination_method, limit, offset)

--- a/clients/python/client/osparc/_solvers_api.py
+++ b/clients/python/client/osparc/_solvers_api.py
@@ -1,0 +1,34 @@
+from typing import Any, Iterator
+
+from osparc_client import SolversApi as _SolversApi
+
+from . import ApiClient, Job
+
+
+class SolversApi:
+    """Class for interacting with solvers"""
+
+    def __init__(self, api_client: ApiClient):
+        """Construct object
+
+        Args:
+            api_client (ApiClient): osparc.ApiClient object
+        """
+        self._api_client: ApiClient = api_client
+        self._solvers_api: _SolversApi = _SolversApi(api_client)
+
+    def get_jobs(self, solver_key: str, version: str, **kwargs) -> Iterator[Job]:
+        """Returns an iterator through which one can iterate over all Jobs submitted to the solver
+
+        Args:
+            solver_key (str): The solver key
+            version (str): The solver version
+
+        Yields:
+            Iterator[Job]: An iterator whose elements are the Jobs submitted to the solver
+        """
+        limit: int = 20
+        offset: int = 0
+
+    def __getattr__(self, __name: str) -> Any:
+        return getattr(self._solvers_api, __name)

--- a/clients/python/client/osparc/_solvers_api.py
+++ b/clients/python/client/osparc/_solvers_api.py
@@ -6,10 +6,8 @@ from . import ApiClient, Job
 from ._utils import _pagination_to_iterator
 
 
-class SolversApi:
+class SolversApi(_SolversApi):
     """Class for interacting with solvers"""
-
-    _wrapped_methods: List[str] = ["get_jobs"]
 
     def __init__(self, api_client: ApiClient):
         """Construct object
@@ -17,10 +15,11 @@ class SolversApi:
         Args:
             api_client (ApiClient): osparc.ApiClient object
         """
-        self._api_client: ApiClient = api_client
-        self._solvers_api: _SolversApi = _SolversApi(api_client)
+        super().__init__(api_client)
 
-    def get_jobs(self, solver_key: str, version: str, **kwargs) -> Iterator[Job]:
+    def get_jobs_page(
+        self, solver_key: str, version: str, limit: int = 20
+    ) -> Iterator[Job]:
         """Returns an iterator through which one can iterate over all Jobs submitted to the solver
 
         Args:
@@ -30,13 +29,7 @@ class SolversApi:
         Yields:
             Iterator[Job]: An iterator whose elements are the Jobs submitted to the solver
         """
-        pagination_method = lambda limit, offset: self._solvers_api.get_jobs_page(
+        pagination_method = lambda limit, offset: super(SolversApi, self).get_jobs_page(
             solver_key=solver_key, version=version, limit=limit, offset=offset
         )
-        return _pagination_to_iterator(pagination_method=pagination_method)
-
-    def __getattr__(self, name: str) -> Any:
-        if name in self._wrapped_methods:
-            return getattr(self, name)
-        else:
-            return getattr(self._solvers_api, name)
+        return _pagination_to_iterator(pagination_method=pagination_method, limit=limit)

--- a/clients/python/client/osparc/_solvers_api.py
+++ b/clients/python/client/osparc/_solvers_api.py
@@ -1,4 +1,4 @@
-from typing import Any, Iterator, List, Tuple
+from typing import Any, Iterator, List, Optional, Tuple
 
 from osparc_client import LimitOffsetPageJob
 from osparc_client import SolversApi as _SolversApi
@@ -10,11 +10,11 @@ from ._utils import _pagination_to_iterator
 class SolversApi(_SolversApi):
     """Class for interacting with solvers"""
 
-    def __init__(self, api_client: ApiClient):
+    def __init__(self, api_client: Optional[ApiClient] = None):
         """Construct object
 
         Args:
-            api_client (ApiClient): osparc.ApiClient object
+            api_client (ApiClient, optinal): osparc.ApiClient object
         """
         super().__init__(api_client)
 

--- a/clients/python/client/osparc/_utils.py
+++ b/clients/python/client/osparc/_utils.py
@@ -38,8 +38,6 @@ def _pagination_to_iterator(
         page: Page = pagination_method(limit, offset)
         assert page.items is not None
         assert isinstance(page.total, int)
-        print(f"page.total = {page.total}")
-        print(f"page = {page}")
         for item in page.items:
             item_count += 1
             yield item

--- a/clients/python/client/osparc/_utils.py
+++ b/clients/python/client/osparc/_utils.py
@@ -41,6 +41,6 @@ def _pagination_to_iterator(
         for item in page.items:
             item_count += 1
             yield item
-        offset += limit
+        offset += len(page.items)
         if item_count >= page.total:
             break

--- a/clients/python/client/osparc/_utils.py
+++ b/clients/python/client/osparc/_utils.py
@@ -18,7 +18,7 @@ T = TypeVar("T", Job, File, Solver, Study)
 
 
 class PaginationGenerator:
-    """Class for wrapping paginated http methods as iterators"""
+    """Class for wrapping paginated http methods as generators"""
 
     def __init__(
         self,

--- a/clients/python/client/osparc/_utils.py
+++ b/clients/python/client/osparc/_utils.py
@@ -1,4 +1,4 @@
-from typing import Callable, Iterator, TypeVar, Union
+from typing import Callable, Generator, TypeVar, Union
 
 from osparc_client import (
     File,
@@ -17,7 +17,7 @@ Page = Union[
 T = TypeVar("T", Job, File, Solver, Study)
 
 
-class PaginationIterator:
+class PaginationGenerator:
     """Class for wrapping paginated http methods as iterators"""
 
     def __init__(
@@ -43,11 +43,11 @@ class PaginationIterator:
         ), f"page.total={page.total} must be a nonnegative interger"
         return max(page.total - self._offset, 0)
 
-    def __iter__(self) -> Iterator[T]:
-        """Returns the iterator
+    def __iter__(self) -> Generator[T, None, None]:
+        """Returns the generator
 
         Yields:
-            Iterator[T]: The returned iterator
+            Generator[T,None,None]: The returned generator
         """
         if len(self) == 0:
             return

--- a/clients/python/client/osparc/_utils.py
+++ b/clients/python/client/osparc/_utils.py
@@ -17,27 +17,46 @@ Page = Union[
 T = TypeVar("T", Job, File, Solver, Study)
 
 
-def _pagination_to_iterator(
-    pagination_method: Callable[[int, int], Page], limit: int = 20, offset: int = 0
-) -> Iterator[T]:
-    """Returns an iterator given a pagination entrypoint
+class PaginationIterator:
+    """Class for wrapping paginated http methods as iterators"""
 
-    Args:
-        pagination_method (Callable[[int, int], Page]): A lambda which takes as first input the limit and as second input the offset of the page
-        limit (int, optional): Limit of the page. Defaults to 20.
+    def __init__(
+        self,
+        pagination_method: Callable[[int, int], Page],
+        limit: int = 20,
+        offset: int = 0,
+    ):
+        self._pagination_method: Callable[[int, int], Page] = pagination_method
+        self._limit: int = limit
+        self._offset: int = offset
 
-    Raises:
-        StopIteration: Raised when one has iterated through all elements in the iterator
+    def __len__(self) -> int:
+        """Number of elements which the iterator can produce
 
-    Yields:
-        Iterator[T]: The returned iterator
-    """
-    while True:
-        page: Page = pagination_method(limit, offset)
-        assert page.items is not None
+        Returns:
+            int: The number of elements the iterator can produce
+        """
+        page: Page = self._pagination_method(self._limit, 0)
         assert isinstance(page.total, int)
-        for item in page.items:
-            yield item
-        offset += len(page.items)
-        if offset >= page.total:
-            break
+        assert (
+            page.total >= 0
+        ), f"page.total={page.total} must be a nonnegative interger"
+        return max(page.total - self._offset, 0)
+
+    def __iter__(self) -> Iterator[T]:
+        """Returns the iterator
+
+        Yields:
+            Iterator[T]: The returned iterator
+        """
+        if len(self) == 0:
+            return
+        while True:
+            page: Page = self._pagination_method(self._limit, self._offset)
+            assert page.items is not None
+            assert isinstance(page.total, int)
+            for item in page.items:
+                yield item
+            self._offset += len(page.items)
+            if self._offset >= page.total:
+                break

--- a/clients/python/client/osparc/_utils.py
+++ b/clients/python/client/osparc/_utils.py
@@ -18,7 +18,7 @@ T = TypeVar("T", Job, File, Solver, Study)
 
 
 def _pagination_to_iterator(
-    pagination_method: Callable[[int, int], Page], limit: int = 20
+    pagination_method: Callable[[int, int], Page], limit: int = 20, offset: int = 0
 ) -> Iterator[T]:
     """Returns an iterator given a pagination entrypoint
 
@@ -32,15 +32,12 @@ def _pagination_to_iterator(
     Yields:
         Iterator[T]: The returned iterator
     """
-    offset: int = 0
-    item_count: int = 0
     while True:
         page: Page = pagination_method(limit, offset)
         assert page.items is not None
         assert isinstance(page.total, int)
         for item in page.items:
-            item_count += 1
             yield item
         offset += len(page.items)
-        if item_count >= page.total:
+        if offset >= page.total:
             break

--- a/clients/python/client/osparc/_utils.py
+++ b/clients/python/client/osparc/_utils.py
@@ -1,5 +1,46 @@
-from typing import Any, Callable, Iterator
+from typing import Any, Callable, Iterator, TypeVar, Union
+
+from osparc_client import (
+    File,
+    Job,
+    LimitOffsetPageFile,
+    LimitOffsetPageJob,
+    LimitOffsetPageSolver,
+    LimitOffsetPageStudy,
+    Solver,
+    Study,
+)
+
+Page = Union[
+    LimitOffsetPageJob, LimitOffsetPageFile, LimitOffsetPageSolver, LimitOffsetPageStudy
+]
+T = TypeVar("T", Job, File, Solver, Study)
 
 
-def _pagination_to_iterator(pagination_method: Callable) -> Iterator[Any]:
-    pass
+def _pagination_to_iterator(
+    pagination_method: Callable[[int, int], Page], limit: int = 20
+) -> Iterator[T]:
+    """Returns an iterator given a pagination entrypoint
+
+    Args:
+        pagination_method (Callable[[int, int], Page]): A lambda which takes as first input the limit and as second input the offset of the page
+        limit (int, optional): Limit of the page. Defaults to 20.
+
+    Raises:
+        StopIteration: Raised when one has iterated through all elements in the iterator
+
+    Yields:
+        Iterator[T]: The returned iterator
+    """
+    offset: int = 0
+    item_count: int = 0
+    while True:
+        page: Page = pagination_method(limit, offset)
+        assert page.items is not None
+        assert isinstance(page.total, int)
+        for item in page.items:
+            item_count += 1
+            yield item
+        offset += limit
+        if item_count >= page.total:
+            raise StopIteration

--- a/clients/python/client/osparc/_utils.py
+++ b/clients/python/client/osparc/_utils.py
@@ -1,4 +1,4 @@
-from typing import Any, Callable, Iterator, TypeVar, Union
+from typing import Callable, Iterator, TypeVar, Union
 
 from osparc_client import (
     File,

--- a/clients/python/client/osparc/_utils.py
+++ b/clients/python/client/osparc/_utils.py
@@ -55,8 +55,7 @@ class PaginationIterator:
             page: Page = self._pagination_method(self._limit, self._offset)
             assert page.items is not None
             assert isinstance(page.total, int)
-            for item in page.items:
-                yield item
+            yield from page.items
             self._offset += len(page.items)
             if self._offset >= page.total:
                 break

--- a/clients/python/client/osparc/_utils.py
+++ b/clients/python/client/osparc/_utils.py
@@ -1,0 +1,5 @@
+from typing import Any, Callable, Iterator
+
+
+def _pagination_to_iterator(pagination_method: Callable) -> Iterator[Any]:
+    pass

--- a/clients/python/client/osparc/_utils.py
+++ b/clients/python/client/osparc/_utils.py
@@ -38,9 +38,11 @@ def _pagination_to_iterator(
         page: Page = pagination_method(limit, offset)
         assert page.items is not None
         assert isinstance(page.total, int)
+        print(f"page.total = {page.total}")
+        print(f"page = {page}")
         for item in page.items:
             item_count += 1
             yield item
         offset += limit
         if item_count >= page.total:
-            raise StopIteration
+            break

--- a/clients/python/client/osparc/api.py
+++ b/clients/python/client/osparc/api.py
@@ -1,14 +1,16 @@
 import warnings
 from typing import Final, Tuple
 
+from osparc_client.api import FilesApi, MetaApi, SolversApi, UsersApi
+
 from ._warnings_and_errors import VisibleDeprecationWarning
 
 warning_msg: Final[str] = (
-    "osparc.api has been deprecated. Instead functionality within this module should be imported directly from osparc. "
-    "I.e. please do 'from osparc import <fcn>' instead of 'from osparc.api import <fcn>'"
+    "osparc.api has been deprecated. Instead functionality within this module "
+    "should be imported directly from osparc. I.e. please do 'from osparc import "
+    "<fcn>' instead of 'from osparc.api import <fcn>'"
 )
 warnings.warn(warning_msg, VisibleDeprecationWarning)
 
-from osparc_client.api import FilesApi, MetaApi, SolversApi, UsersApi
 
 __all__: Tuple[str, ...] = ("FilesApi", "MetaApi", "SolversApi", "UsersApi")

--- a/clients/python/client/osparc/models.py
+++ b/clients/python/client/osparc/models.py
@@ -1,15 +1,6 @@
 import warnings
 from typing import Final, Tuple
 
-from ._warnings_and_errors import VisibleDeprecationWarning
-
-warning_msg: Final[str] = (
-    "osparc.models has been deprecated. Instead functionality within this module should be imported directly from osparc. "
-    "I.e. please do 'from osparc import <fcn>' instead of 'from osparc.models import <fcn>'"
-)
-warnings.warn(warning_msg, VisibleDeprecationWarning)
-
-
 from osparc_client.models import (
     BodyUploadFileV0FilesContentPut,
     File,
@@ -25,6 +16,16 @@ from osparc_client.models import (
 )
 from osparc_client.models import RunningState as TaskStates
 from osparc_client.models import Solver, UserRoleEnum, UsersGroup, ValidationError
+
+from ._warnings_and_errors import VisibleDeprecationWarning
+
+warning_msg: Final[str] = (
+    "osparc.models has been deprecated. Instead functionality within this module "
+    "should be imported directly from osparc. I.e. please do 'from osparc import "
+    "<fcn>' instead of 'from osparc.models import <fcn>'"
+)
+warnings.warn(warning_msg, VisibleDeprecationWarning)
+
 
 __all__: Tuple[str, ...] = (
     "BodyUploadFileV0FilesContentPut",

--- a/clients/python/test/e2e/ci/_utils.py
+++ b/clients/python/test/e2e/ci/_utils.py
@@ -8,7 +8,7 @@ from packaging.version import Version
 from pydantic import BaseModel, field_validator, model_validator
 
 
-# classed for handling errors -------------------------------------------------------------------------
+# classed for handling errors ----------------------------------
 class E2eScriptFailure(UserWarning):
     """Simply used to indicate a CI script failure"""
 
@@ -17,7 +17,8 @@ class E2eScriptFailure(UserWarning):
 
 class E2eExitCodes(IntEnum):
     """Exitcodes
-    Note these should not clash with pytest exitcodes: https://docs.pytest.org/en/7.1.x/reference/exit-codes.html
+    Note these should not clash with pytest exitcodes:
+    https://docs.pytest.org/en/7.1.x/reference/exit-codes.html
     """
 
     CI_SCRIPT_FAILURE = 100
@@ -32,7 +33,7 @@ assert (
     == set()
 )
 
-# Data classes ----------------------------------------------------------------------------------------
+# Data classes ----------------------------------------------
 
 
 class ServerConfig(BaseModel):
@@ -46,7 +47,7 @@ class ServerConfig(BaseModel):
     def check_url(cls, v):
         try:
             _ = urlparse(v)
-        except:
+        except Exception:
             raise ValueError("Could not parse 'OSPARC_API_HOST'. Received {v}.")
         return v
 
@@ -63,7 +64,8 @@ class ServerConfig(BaseModel):
         return self.OSPARC_API_SECRET
 
 
-is_empty = lambda v: v is None or v == ""
+def is_empty(v):
+    return v is None or v == ""
 
 
 class ClientConfig(BaseModel):
@@ -82,15 +84,17 @@ class ClientConfig(BaseModel):
         if (not is_empty(v)) and (not v == "latest"):
             try:
                 _ = Version(v)
-            except:
+            except Exception:
                 raise ValueError(f"Did not receive valid version: {v}")
         return v
 
     @model_validator(mode="after")
     def check_consistency(self) -> "ClientConfig":
         msg: str = (
-            f"Recieved OSPARC_CLIENT_VERSION={self.OSPARC_CLIENT_VERSION}, OSPARC_CLIENT_REPO={self.OSPARC_CLIENT_REPO}"
-            "and OSPARC_CLIENT_BRANCH={self.OSPARC_CLIENT_BRANCH}. Either a version or a repo, branch pair must be specified. Not both."
+            f"Recieved OSPARC_CLIENT_VERSION={self.OSPARC_CLIENT_VERSION}, "
+            f"OSPARC_CLIENT_REPO={self.OSPARC_CLIENT_REPO}"
+            "and OSPARC_CLIENT_BRANCH={self.OSPARC_CLIENT_BRANCH}. "
+            "Either a version or a repo, branch pair must be specified. Not both."
         )
         # check at least one is empty
         if not (
@@ -156,7 +160,7 @@ class ClientConfig(BaseModel):
             return self.branch
 
 
-# Paths ---------------------------------------------------------------------------------------------
+# Paths -------------------------------------------------------
 
 _E2E_DIR: Path = Path(__file__).parent.parent.resolve()
 _CI_DIR: Path = (_E2E_DIR / "ci").resolve()

--- a/clients/python/test/e2e/ci/compatible_client_server.py
+++ b/clients/python/test/e2e/ci/compatible_client_server.py
@@ -13,7 +13,12 @@ from pydantic import ValidationError
 
 
 def main() -> None:
-    """Checks if the client x server configuration in the pyproject.toml is compatible"""
+    """Checks if the client x server configuration in the pyproject.toml
+    is compatible
+
+    Raises:
+        typer.Exit: When exit code is returned
+    """
     try:
         pytest_envs = toml.load(_PYPROJECT_TOML)["tool"]["pytest"]["ini_options"]["env"]
         client_cfg: ClientConfig = ClientConfig(**toml.load(_PYPROJECT_TOML)["client"])
@@ -26,14 +31,16 @@ def main() -> None:
 
     compatibility_df: pd.DataFrame = pd.read_json(_COMPATIBILITY_JSON)
 
-    if not client_cfg.compatibility_ref in compatibility_df.columns:
+    if client_cfg.compatibility_ref not in compatibility_df.columns:
         print(
-            f"The client ref '{client_cfg.compatibility_ref}' could not be found in {_COMPATIBILITY_JSON}"
+            f"The client ref '{client_cfg.compatibility_ref}' could not "
+            f"be found in {_COMPATIBILITY_JSON}"
         )
         raise typer.Exit(code=E2eExitCodes.INVALID_CLIENT_VS_SERVER)
-    if not server_cfg.url.netloc in compatibility_df.index:
+    if server_cfg.url.netloc not in compatibility_df.index:
         print(
-            f"The server netloc '{server_cfg.url.netloc}' could not be found in {_COMPATIBILITY_JSON}"
+            f"The server netloc '{server_cfg.url.netloc}' could not "
+            f"be found in {_COMPATIBILITY_JSON}"
         )
 
     if not compatibility_df[client_cfg.compatibility_ref][server_cfg.url.netloc]:

--- a/clients/python/test/e2e/ci/postprocess_e2e.py
+++ b/clients/python/test/e2e/ci/postprocess_e2e.py
@@ -1,9 +1,7 @@
-import json
 import shutil
 import warnings
 from pathlib import Path
-from typing import List, Set
-from urllib.parse import urlparse
+from typing import Set
 
 import pandas as pd
 import pytest
@@ -23,12 +21,15 @@ from pydantic import ValidationError
 def main(exit_code: int) -> None:
     """
     Postprocess results from e2e pytests
-    This scripts appends the pytest exit code to clients/python/artifacts/e2e/<client_ref>.json for it to be parsed later
-    It also moves the pyproject.toml to clients/python/artifacts/e2e in order to be able to reproduce tests later
+    This scripts appends the pytest exit code to
+    clients/python/artifacts/e2e/<client_ref>.json for it to be parsed later.
+    It also moves the pyproject.toml to clients/python/artifacts/e2e in order
+    to be able to reproduce tests later
 
     arguments:
     ----------
-        exit_code : Integer exit code from running pytests or a custom exitcode (see ExitCodes).
+        exit_code : Integer exit code from running pytests or a
+        custom exitcode (see ExitCodes).
 
     returns:
     --------
@@ -39,7 +40,7 @@ def main(exit_code: int) -> None:
         pytest.ExitCode.OK,
         pytest.ExitCode.TESTS_FAILED,
     }
-    if not exit_code in expected_exitcodes:
+    if exit_code not in expected_exitcodes:
         warnings.warn(
             f"Received unexpected exitcode {exit_code}. See https://docs.pytest.org/en/7.1.x/reference/exit-codes.html",
             E2eScriptFailure,
@@ -55,7 +56,7 @@ def main(exit_code: int) -> None:
     try:
         server_cfg: ServerConfig = ServerConfig(**toml.load(_PYPROJECT_TOML)["server"])
         client_cfg: ClientConfig = ClientConfig(**toml.load(_PYPROJECT_TOML)["client"])
-    except (ValueError, ValidationError) as e:
+    except (ValueError, ValidationError):
         print(toml.load(_PYPROJECT_TOML)["server"])
         print(print(toml.load(_PYPROJECT_TOML)["client"]))
         raise typer.Exit(code=E2eExitCodes.INVALID_JSON_DATA)

--- a/clients/python/test/e2e/test_notebooks.py
+++ b/clients/python/test/e2e/test_notebooks.py
@@ -1,7 +1,6 @@
 import shutil
 import sys
 from pathlib import Path
-from tempfile import TemporaryDirectory
 from typing import Any, List
 
 import osparc

--- a/clients/python/test/e2e/test_notebooks.py
+++ b/clients/python/test/e2e/test_notebooks.py
@@ -9,7 +9,7 @@ import papermill as pm
 import pytest
 
 docs_dir: Path = Path(__file__).parent.parent.parent / "docs"
-all_notebooks: List[Path] = list(docs_dir.glob("*.ipynb"))
+all_notebooks: List[Path] = list(docs_dir.rglob("*.ipynb"))
 
 
 def test_notebook_config(tmp_path: Path):

--- a/clients/python/test/e2e/test_solvers_api.py
+++ b/clients/python/test/e2e/test_solvers_api.py
@@ -2,6 +2,7 @@ import os
 
 import osparc
 import pytest
+from packaging.version import Version
 
 
 @pytest.fixture
@@ -20,7 +21,7 @@ def configuration() -> osparc.Configuration:
 
 
 @pytest.mark.skipif(
-    osparc.__version__ < "0.6.0",
+    Version(osparc.__version__) < Version("0.6.0"),
     reason=f"osparc.__version__={osparc.__version__} is older than 0.6.0",
 )
 def test_get_jobs(configuration: osparc.Configuration):
@@ -31,21 +32,33 @@ def test_get_jobs(configuration: osparc.Configuration):
     """
     solver: str = "simcore/services/comp/itis/sleeper"
     version: str = "2.0.2"
-    n_jobs: int = 10
+    n_jobs: int = 3
     with osparc.ApiClient(configuration) as api_client:
         solvers_api: osparc.SolversApi = osparc.SolversApi(api_client)
         sleeper: osparc.Solver = solvers_api.get_solver_release(solver, version)
 
         # delete old jobs
-        for job in solvers_api.get_jobs(sleeper.id, sleeper.version, limit=3):
-            solvers_api.delete_job(sleeper.id, sleeper.version, job.id)
+        _, init_job_count = solvers_api.get_jobs(sleeper.id, sleeper.version, limit=3)
 
         # create n_jobs jobs
+        created_job_ids = []
         for _ in range(n_jobs):
-            solvers_api.create_job(
+            job: osparc.Job = solvers_api.create_job(
                 sleeper.id, sleeper.version, osparc.JobInputs({"input1": 1.0})
             )
+            created_job_ids.append(job.id)
 
-        assert n_jobs == sum(
-            1 for _ in solvers_api.get_jobs(sleeper.id, sleeper.version)
+        job_iter, job_count = solvers_api.get_jobs(
+            sleeper.id, sleeper.version, limit=3, offset=init_job_count
         )
+        assert job_count > 0, "No jobs were available"
+        assert (
+            init_job_count + n_jobs == job_count
+        ), "An incorrect number of jobs was recorded"
+
+        for job in job_iter:
+            assert isinstance(job, osparc.Job)
+
+        # cleanup
+        for elm in created_job_ids:
+            solvers_api.delete_job(sleeper.id, sleeper.version, elm)

--- a/clients/python/test/e2e/test_solvers_api.py
+++ b/clients/python/test/e2e/test_solvers_api.py
@@ -48,12 +48,13 @@ def test_get_jobs(configuration: osparc.Configuration):
             )
             created_job_ids.append(job.id)
 
-        job_iter, job_count = solvers_api.get_jobs(
+        job_iter, job_iter_len = solvers_api.get_jobs(
             sleeper.id, sleeper.version, limit=3, offset=init_job_count
         )
-        assert job_count > 0, "No jobs were available"
+        _, total_job_count = solvers_api.get_jobs(sleeper.id, sleeper.version, limit=3)
+        assert job_iter_len > 0, "No jobs were available"
         assert (
-            init_job_count + n_jobs == job_count
+            init_job_count + n_jobs == total_job_count
         ), "An incorrect number of jobs was recorded"
 
         for job in job_iter:

--- a/clients/python/test/e2e/test_solvers_api.py
+++ b/clients/python/test/e2e/test_solvers_api.py
@@ -37,8 +37,10 @@ def test_get_jobs(configuration: osparc.Configuration):
         solvers_api: osparc.SolversApi = osparc.SolversApi(api_client)
         sleeper: osparc.Solver = solvers_api.get_solver_release(solver, version)
 
-        # delete old jobs
-        _, init_job_count = solvers_api.get_jobs(sleeper.id, sleeper.version, limit=3)
+        # initial iterator
+        init_iter = solvers_api.get_jobs(sleeper.id, sleeper.version, limit=3)
+        n_init_iter: int = len(init_iter)
+        assert n_init_iter >= 0
 
         # create n_jobs jobs
         created_job_ids = []
@@ -48,17 +50,18 @@ def test_get_jobs(configuration: osparc.Configuration):
             )
             created_job_ids.append(job.id)
 
-        job_iter, job_iter_len = solvers_api.get_jobs(
-            sleeper.id, sleeper.version, limit=3, offset=init_job_count
+        tmp_iter = solvers_api.get_jobs(
+            sleeper.id, sleeper.version, limit=3, offset=n_init_iter
         )
-        _, total_job_count = solvers_api.get_jobs(sleeper.id, sleeper.version, limit=3)
-        assert job_iter_len > 0, "No jobs were available"
-        assert (
-            init_job_count + n_jobs == total_job_count
+
+        final_iter = solvers_api.get_jobs(sleeper.id, sleeper.version, limit=3)
+        assert len(final_iter) > 0, "No jobs were available"
+        assert n_init_iter + n_jobs == len(
+            final_iter
         ), "An incorrect number of jobs was recorded"
 
-        for job in job_iter:
-            assert isinstance(job, osparc.Job)
+        for elm in tmp_iter:
+            assert isinstance(elm, osparc.Job)
 
         # cleanup
         for elm in created_job_ids:

--- a/clients/python/test/e2e/test_solvers_api.py
+++ b/clients/python/test/e2e/test_solvers_api.py
@@ -19,7 +19,11 @@ def configuration() -> osparc.Configuration:
     return cfg
 
 
-def test_get_jobs_page(configuration: osparc.Configuration):
+@pytest.mark.skipif(
+    osparc.__version__ < "0.6.0",
+    reason=f"osparc.__version__={osparc.__version__} is older than 0.6.0",
+)
+def test_get_jobs(configuration: osparc.Configuration):
     """Test the get_jobs method
 
     Args:
@@ -27,6 +31,21 @@ def test_get_jobs_page(configuration: osparc.Configuration):
     """
     solver: str = "simcore/services/comp/itis/sleeper"
     version: str = "2.0.2"
+    n_jobs: int = 10
     with osparc.ApiClient(configuration) as api_client:
         solvers_api: osparc.SolversApi = osparc.SolversApi(api_client)
         sleeper: osparc.Solver = solvers_api.get_solver_release(solver, version)
+
+        # delete old jobs
+        for job in solvers_api.get_jobs(sleeper.id, sleeper.version, limit=3):
+            solvers_api.delete_job(sleeper.id, sleeper.version, job.id)
+
+        # create n_jobs jobs
+        for _ in range(n_jobs):
+            solvers_api.create_job(
+                sleeper.id, sleeper.version, osparc.JobInputs({"input1": 1.0})
+            )
+
+        assert n_jobs == sum(
+            1 for _ in solvers_api.get_jobs(sleeper.id, sleeper.version)
+        )

--- a/clients/python/test/e2e/test_solvers_api.py
+++ b/clients/python/test/e2e/test_solvers_api.py
@@ -1,0 +1,32 @@
+import os
+
+import osparc
+import pytest
+
+
+@pytest.fixture
+def configuration() -> osparc.Configuration:
+    """Configuration
+
+    Returns:
+        osparc.Configuration: The Configuration
+    """
+    cfg = osparc.Configuration(
+        host=os.environ["OSPARC_API_HOST"],
+        username=os.environ["OSPARC_API_KEY"],
+        password=os.environ["OSPARC_API_SECRET"],
+    )
+    return cfg
+
+
+def test_get_jobs_page(configuration: osparc.Configuration):
+    """Test the get_jobs method
+
+    Args:
+        configuration (osparc.Configuration): The Configuration
+    """
+    solver: str = "simcore/services/comp/itis/sleeper"
+    version: str = "2.0.2"
+    with osparc.ApiClient(configuration) as api_client:
+        solvers_api: osparc.SolversApi = osparc.SolversApi(api_client)
+        sleeper: osparc.Solver = solvers_api.get_solver_release(solver, version)

--- a/clients/python/test/test_osparc/test_osparc_client/test_body_upload_file_v0_files_content_put.py
+++ b/clients/python/test/test_osparc/test_osparc_client/test_body_upload_file_v0_files_content_put.py
@@ -12,12 +12,9 @@
 
 from __future__ import absolute_import
 
-import datetime
 import unittest
 
-import osparc
 from osparc import BodyUploadFileV0FilesContentPut  # noqa: E501
-from osparc import ApiException
 
 
 class TestBodyUploadFileV0FilesContentPut(unittest.TestCase):
@@ -44,8 +41,8 @@ class TestBodyUploadFileV0FilesContentPut(unittest.TestCase):
 
     def testBodyUploadFileV0FilesContentPut(self):
         """Test BodyUploadFileV0FilesContentPut"""
-        inst_req_only = self.make_instance(include_optional=False)
-        inst_req_and_optional = self.make_instance(include_optional=True)
+        self.make_instance(include_optional=False)
+        self.make_instance(include_optional=True)
 
 
 if __name__ == "__main__":

--- a/clients/python/test/test_osparc/test_osparc_client/test_file.py
+++ b/clients/python/test/test_osparc/test_osparc_client/test_file.py
@@ -12,12 +12,9 @@
 
 from __future__ import absolute_import
 
-import datetime
 import unittest
 
-import osparc
 from osparc import File  # noqa: E501
-from osparc import ApiException
 
 
 class TestFile(unittest.TestCase):
@@ -45,8 +42,8 @@ class TestFile(unittest.TestCase):
 
     def testFile(self):
         """Test File"""
-        inst_req_only = self.make_instance(include_optional=False)
-        inst_req_and_optional = self.make_instance(include_optional=True)
+        self.make_instance(include_optional=False)
+        self.make_instance(include_optional=True)
 
 
 if __name__ == "__main__":

--- a/clients/python/test/test_osparc/test_osparc_client/test_files_api.py
+++ b/clients/python/test/test_osparc/test_osparc_client/test_files_api.py
@@ -14,9 +14,7 @@ from __future__ import absolute_import
 
 import unittest
 
-import osparc
 from osparc import FilesApi  # noqa: E501
-from osparc import ApiException
 
 
 class TestFilesApi(unittest.TestCase):

--- a/clients/python/test/test_osparc/test_osparc_client/test_groups.py
+++ b/clients/python/test/test_osparc/test_osparc_client/test_groups.py
@@ -12,11 +12,9 @@
 
 from __future__ import absolute_import
 
-import datetime
 import unittest
 
-import osparc
-from osparc import ApiException, Groups, UsersGroup  # noqa: E501
+from osparc import Groups, UsersGroup  # noqa: E501
 
 
 class TestGroups(unittest.TestCase):
@@ -70,8 +68,8 @@ class TestGroups(unittest.TestCase):
 
     def testGroups(self):
         """Test Groups"""
-        inst_req_only = self.make_instance(include_optional=False)
-        inst_req_and_optional = self.make_instance(include_optional=True)
+        self.make_instance(include_optional=False)
+        self.make_instance(include_optional=True)
 
 
 if __name__ == "__main__":

--- a/clients/python/test/test_osparc/test_osparc_client/test_http_validation_error.py
+++ b/clients/python/test/test_osparc/test_osparc_client/test_http_validation_error.py
@@ -12,12 +12,10 @@
 
 from __future__ import absolute_import
 
-import datetime
 import unittest
 
-import osparc
 from osparc import HTTPValidationError  # noqa: E501
-from osparc import ApiException, ValidationError
+from osparc import ValidationError
 
 
 class TestHTTPValidationError(unittest.TestCase):
@@ -50,8 +48,8 @@ class TestHTTPValidationError(unittest.TestCase):
 
     def testHTTPValidationError(self):
         """Test HTTPValidationError"""
-        inst_req_only = self.make_instance(include_optional=False)
-        inst_req_and_optional = self.make_instance(include_optional=True)
+        self.make_instance(include_optional=False)
+        self.make_instance(include_optional=True)
 
 
 if __name__ == "__main__":

--- a/clients/python/test/test_osparc/test_osparc_client/test_job.py
+++ b/clients/python/test/test_osparc/test_osparc_client/test_job.py
@@ -15,9 +15,7 @@ from __future__ import absolute_import
 import datetime
 import unittest
 
-import osparc
 from osparc import Job  # noqa: E501
-from osparc import ApiException
 
 
 class TestJob(unittest.TestCase):
@@ -64,8 +62,8 @@ class TestJob(unittest.TestCase):
 
     def testJob(self):
         """Test Job"""
-        inst_req_only = self.make_instance(include_optional=False)
-        inst_req_and_optional = self.make_instance(include_optional=True)
+        self.make_instance(include_optional=False)
+        self.make_instance(include_optional=True)
 
 
 if __name__ == "__main__":

--- a/clients/python/test/test_osparc/test_osparc_client/test_job_inputs.py
+++ b/clients/python/test/test_osparc/test_osparc_client/test_job_inputs.py
@@ -12,12 +12,9 @@
 
 from __future__ import absolute_import
 
-import datetime
 import unittest
 
-import osparc
 from osparc import JobInputs  # noqa: E501
-from osparc import ApiException
 
 
 class TestJobInputs(unittest.TestCase):
@@ -44,8 +41,8 @@ class TestJobInputs(unittest.TestCase):
 
     def testJobInputs(self):
         """Test JobInputs"""
-        inst_req_only = self.make_instance(include_optional=False)
-        inst_req_and_optional = self.make_instance(include_optional=True)
+        self.make_instance(include_optional=False)
+        self.make_instance(include_optional=True)
 
 
 if __name__ == "__main__":

--- a/clients/python/test/test_osparc/test_osparc_client/test_job_outputs.py
+++ b/clients/python/test/test_osparc/test_osparc_client/test_job_outputs.py
@@ -12,12 +12,9 @@
 
 from __future__ import absolute_import
 
-import datetime
 import unittest
 
-import osparc
 from osparc import JobOutputs  # noqa: E501
-from osparc import ApiException
 
 
 class TestJobOutputs(unittest.TestCase):
@@ -45,8 +42,8 @@ class TestJobOutputs(unittest.TestCase):
 
     def testJobOutputs(self):
         """Test JobOutputs"""
-        inst_req_only = self.make_instance(include_optional=False)
-        inst_req_and_optional = self.make_instance(include_optional=True)
+        self.make_instance(include_optional=False)
+        self.make_instance(include_optional=True)
 
 
 if __name__ == "__main__":

--- a/clients/python/test/test_osparc/test_osparc_client/test_job_status.py
+++ b/clients/python/test/test_osparc/test_osparc_client/test_job_status.py
@@ -15,9 +15,7 @@ from __future__ import absolute_import
 import datetime
 import unittest
 
-import osparc
 from osparc import JobStatus  # noqa: E501
-from osparc import ApiException
 
 
 class TestJobStatus(unittest.TestCase):
@@ -61,8 +59,8 @@ class TestJobStatus(unittest.TestCase):
 
     def testJobStatus(self):
         """Test JobStatus"""
-        inst_req_only = self.make_instance(include_optional=False)
-        inst_req_and_optional = self.make_instance(include_optional=True)
+        self.make_instance(include_optional=False)
+        self.make_instance(include_optional=True)
 
 
 if __name__ == "__main__":

--- a/clients/python/test/test_osparc/test_osparc_client/test_meta.py
+++ b/clients/python/test/test_osparc/test_osparc_client/test_meta.py
@@ -12,12 +12,9 @@
 
 from __future__ import absolute_import
 
-import datetime
 import unittest
 
-import osparc
 from osparc import Meta  # noqa: E501
-from osparc import ApiException
 
 
 class TestMeta(unittest.TestCase):
@@ -53,8 +50,8 @@ class TestMeta(unittest.TestCase):
 
     def testMeta(self):
         """Test Meta"""
-        inst_req_only = self.make_instance(include_optional=False)
-        inst_req_and_optional = self.make_instance(include_optional=True)
+        self.make_instance(include_optional=False)
+        self.make_instance(include_optional=True)
 
 
 if __name__ == "__main__":

--- a/clients/python/test/test_osparc/test_osparc_client/test_meta_api.py
+++ b/clients/python/test/test_osparc/test_osparc_client/test_meta_api.py
@@ -14,9 +14,7 @@ from __future__ import absolute_import
 
 import unittest
 
-import osparc
 from osparc import MetaApi  # noqa: E501
-from osparc import ApiException
 
 
 class TestMetaApi(unittest.TestCase):

--- a/clients/python/test/test_osparc/test_osparc_client/test_profile.py
+++ b/clients/python/test/test_osparc/test_osparc_client/test_profile.py
@@ -12,12 +12,10 @@
 
 from __future__ import absolute_import
 
-import datetime
 import unittest
 
-import osparc
 from osparc import Profile  # noqa: E501
-from osparc import ApiException, Groups, UsersGroup
+from osparc import Groups, UsersGroup
 
 
 class TestProfile(unittest.TestCase):
@@ -70,8 +68,8 @@ class TestProfile(unittest.TestCase):
 
     def testProfile(self):
         """Test Profile"""
-        inst_req_only = self.make_instance(include_optional=False)
-        inst_req_and_optional = self.make_instance(include_optional=True)
+        self.make_instance(include_optional=False)
+        self.make_instance(include_optional=True)
 
 
 if __name__ == "__main__":

--- a/clients/python/test/test_osparc/test_osparc_client/test_profile_update.py
+++ b/clients/python/test/test_osparc/test_osparc_client/test_profile_update.py
@@ -12,12 +12,9 @@
 
 from __future__ import absolute_import
 
-import datetime
 import unittest
 
-import osparc
 from osparc import ProfileUpdate  # noqa: E501
-from osparc import ApiException
 
 
 class TestProfileUpdate(unittest.TestCase):
@@ -42,8 +39,8 @@ class TestProfileUpdate(unittest.TestCase):
 
     def testProfileUpdate(self):
         """Test ProfileUpdate"""
-        inst_req_only = self.make_instance(include_optional=False)
-        inst_req_and_optional = self.make_instance(include_optional=True)
+        self.make_instance(include_optional=False)
+        self.make_instance(include_optional=True)
 
 
 if __name__ == "__main__":

--- a/clients/python/test/test_osparc/test_osparc_client/test_solver.py
+++ b/clients/python/test/test_osparc/test_osparc_client/test_solver.py
@@ -12,12 +12,9 @@
 
 from __future__ import absolute_import
 
-import datetime
 import unittest
 
-import osparc
 from osparc import Solver  # noqa: E501
-from osparc import ApiException
 
 
 class TestSolver(unittest.TestCase):
@@ -55,8 +52,8 @@ class TestSolver(unittest.TestCase):
 
     def testSolver(self):
         """Test Solver"""
-        inst_req_only = self.make_instance(include_optional=False)
-        inst_req_and_optional = self.make_instance(include_optional=True)
+        self.make_instance(include_optional=False)
+        self.make_instance(include_optional=True)
 
 
 if __name__ == "__main__":

--- a/clients/python/test/test_osparc/test_osparc_client/test_solvers_api.py
+++ b/clients/python/test/test_osparc/test_osparc_client/test_solvers_api.py
@@ -14,9 +14,7 @@ from __future__ import absolute_import
 
 import unittest
 
-import osparc
 from osparc import SolversApi  # noqa: E501
-from osparc import ApiException
 
 
 class TestSolversApi(unittest.TestCase):

--- a/clients/python/test/test_osparc/test_osparc_client/test_task_states.py
+++ b/clients/python/test/test_osparc/test_osparc_client/test_task_states.py
@@ -12,12 +12,9 @@
 
 from __future__ import absolute_import
 
-import datetime
 import unittest
 
-import osparc
 from osparc import TaskStates  # noqa: E501
-from osparc import ApiException
 
 
 class TestTaskStates(unittest.TestCase):
@@ -42,8 +39,8 @@ class TestTaskStates(unittest.TestCase):
 
     def testTaskStates(self):
         """Test TaskStates"""
-        inst_req_only = self.make_instance(include_optional=False)
-        inst_req_and_optional = self.make_instance(include_optional=True)
+        self.make_instance(include_optional=False)
+        self.make_instance(include_optional=True)
 
 
 if __name__ == "__main__":

--- a/clients/python/test/test_osparc/test_osparc_client/test_user_role_enum.py
+++ b/clients/python/test/test_osparc/test_osparc_client/test_user_role_enum.py
@@ -12,12 +12,9 @@
 
 from __future__ import absolute_import
 
-import datetime
 import unittest
 
-import osparc
 from osparc import UserRoleEnum  # noqa: E501
-from osparc import ApiException
 
 
 class TestUserRoleEnum(unittest.TestCase):
@@ -42,8 +39,8 @@ class TestUserRoleEnum(unittest.TestCase):
 
     def testUserRoleEnum(self):
         """Test UserRoleEnum"""
-        inst_req_only = self.make_instance(include_optional=False)
-        inst_req_and_optional = self.make_instance(include_optional=True)
+        self.make_instance(include_optional=False)
+        self.make_instance(include_optional=True)
 
 
 if __name__ == "__main__":

--- a/clients/python/test/test_osparc/test_osparc_client/test_users_api.py
+++ b/clients/python/test/test_osparc/test_osparc_client/test_users_api.py
@@ -14,9 +14,7 @@ from __future__ import absolute_import
 
 import unittest
 
-import osparc
 from osparc import UsersApi  # noqa: E501
-from osparc import ApiException
 
 
 class TestUsersApi(unittest.TestCase):

--- a/clients/python/test/test_osparc/test_osparc_client/test_users_group.py
+++ b/clients/python/test/test_osparc/test_osparc_client/test_users_group.py
@@ -12,12 +12,9 @@
 
 from __future__ import absolute_import
 
-import datetime
 import unittest
 
-import osparc
 from osparc import UsersGroup  # noqa: E501
-from osparc import ApiException
 
 
 class TestUsersGroup(unittest.TestCase):
@@ -45,8 +42,8 @@ class TestUsersGroup(unittest.TestCase):
 
     def testUsersGroup(self):
         """Test UsersGroup"""
-        inst_req_only = self.make_instance(include_optional=False)
-        inst_req_and_optional = self.make_instance(include_optional=True)
+        self.make_instance(include_optional=False)
+        self.make_instance(include_optional=True)
 
 
 if __name__ == "__main__":

--- a/clients/python/test/test_osparc/test_osparc_client/test_validation_error.py
+++ b/clients/python/test/test_osparc/test_osparc_client/test_validation_error.py
@@ -12,12 +12,9 @@
 
 from __future__ import absolute_import
 
-import datetime
 import unittest
 
-import osparc
 from osparc import ValidationError  # noqa: E501
-from osparc import ApiException
 
 
 class TestValidationError(unittest.TestCase):
@@ -46,8 +43,8 @@ class TestValidationError(unittest.TestCase):
 
     def testValidationError(self):
         """Test ValidationError"""
-        inst_req_only = self.make_instance(include_optional=False)
-        inst_req_and_optional = self.make_instance(include_optional=True)
+        self.make_instance(include_optional=False)
+        self.make_instance(include_optional=True)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- Common title prefixes/annotations:
PREFIX:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  ♻️     Refactor code.
  🚑️    Critical hotfix.
  ⚗️     Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🗑️    Deprecate code that needs to be cleaned up.
  ⚰️     Remove dead code.
  🔥    Remove code or files.
  🔨    Add or update development scripts.

or from https://gitmoji.dev/
-->

## What do these changes do?
Introduce a python wrapper for the `osparc.SolversApi.get_jobs_page` method which allows the user to get a single iterator to all items in a list, even if the http method is paginated. I have introduces a general function which can be used for the other paginated http methods as soon as they have been implemented on the server side. 
<!-- Explain REVIEWERS what is this PR about -->


## Related issue/s
- https://github.com/ITISFoundation/osparc-simcore-clients/issues/38
<!-- Enumerate REVIEWERS other issues

e.g.

- #26 : node_ports should have retry policies when upload/download fails  (FIXED)
- ITISFoundation/osparc-issues#304: (Part 2) Prep2Go: creating features to support complex S4L scripts (IMPLEMENTED)

-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->
