### PR TITLE
🐛 🧪 Fix e2e client tests

### DIFF
--- a/clients/python/test/e2e/ci/check_for_failures.py
+++ b/clients/python/test/e2e/ci/check_for_failures.py
@@ -23,7 +23,9 @@ def main():
         raise typer.Exit(code=E2eExitCodes.CI_SCRIPT_FAILURE)
     for pth in result_jsons:
         df = pd.read_json(pth)
-        df = df == pytest.ExitCode.TESTS_FAILED
+        df = (df != pytest.ExitCode.OK) & (
+            df != E2eExitCodes.INCOMPATIBLE_CLIENT_SERVER
+        )
         if df.to_numpy().flatten().any():
             raise typer.Exit(code=pytest.ExitCode.TESTS_FAILED)
 

--- a/clients/python/test/e2e/ci/generate_html_table.py
+++ b/clients/python/test/e2e/ci/generate_html_table.py
@@ -26,7 +26,7 @@ def make_pretty(entry: str):
     elif entry == pytest.ExitCode.TESTS_FAILED.name:
         color = "#FF9999"
     else:
-        color = "#8A2BE2"
+        color = "#FF00FF"
     return "background-color: %s" % color
 
 

--- a/clients/python/test/e2e/ci/generate_html_table.py
+++ b/clients/python/test/e2e/ci/generate_html_table.py
@@ -4,30 +4,29 @@ import pandas as pd
 import pytest
 import typer
 from _utils import E2eExitCodes
+from postprocess_e2e import exit_code_valid
 
 
 def exitcode_to_text(exitcode: int) -> str:
     """Turn exitcodes to string"""
-    if exitcode == E2eExitCodes.INCOMPATIBLE_CLIENT_SERVER:
-        return "incompatible"
-    elif exitcode == pytest.ExitCode.OK:
-        return "pass"
-    elif exitcode == pytest.ExitCode.TESTS_FAILED:
-        return "fail"
+    if exitcode in set(E2eExitCodes):
+        return E2eExitCodes(exitcode).name
+    elif exitcode in set(pytest.ExitCode):
+        return pytest.ExitCode(exitcode).name
     else:
         raise typer.Exit(code=E2eExitCodes.CI_SCRIPT_FAILURE)
 
 
 def make_pretty(entry: str):
     color: str
-    if entry == "incompatible":
+    if entry == E2eExitCodes.INCOMPATIBLE_CLIENT_SERVER.name:
         color = "#999999"
-    elif entry == "pass":
+    elif entry == pytest.ExitCode.OK.name:
         color = "#99FF99"
-    elif entry == "fail":
+    elif entry == pytest.ExitCode.TESTS_FAILED.name:
         color = "#FF9999"
     else:
-        raise typer.Exit(code=E2eExitCodes.CI_SCRIPT_FAILURE)
+        color = "#8A2BE2"
     return "background-color: %s" % color
 
 
@@ -40,9 +39,10 @@ def main(e2e_artifacts_dir: str) -> None:
     df: pd.DataFrame = pd.DataFrame()
     for file in artifacts.glob("*.json"):
         df = pd.concat([df, pd.read_json(file)], axis=1)
-    any_failure: bool = bool(
-        (df == pytest.ExitCode.TESTS_FAILED).to_numpy().flatten().any()
-    )
+
+    for exit_code in df.to_numpy().flatten():
+        if not exit_code_valid(exit_code):
+            raise typer.Exit(code=E2eExitCodes.CI_SCRIPT_FAILURE)
 
     style = [
         {
@@ -62,9 +62,6 @@ def main(e2e_artifacts_dir: str) -> None:
     s.set_table_styles(style)
     s.set_caption("OSPARC e2e python client vs server tests")
     s.to_html(artifacts / "test_results.html")
-    raise typer.Exit(
-        code=pytest.ExitCode.TESTS_FAILED if any_failure else pytest.ExitCode.OK
-    )
 
 
 if __name__ == "__main__":

--- a/clients/python/test/e2e/test_files_api.py
+++ b/clients/python/test/e2e/test_files_api.py
@@ -4,7 +4,6 @@ from pathlib import Path
 import osparc
 import pytest
 from conftest import _KB
-from osparc._utils import compute_sha256
 from packaging.version import Version
 
 
@@ -51,8 +50,7 @@ def test_upload_file(tmp_file: Path, cfg: osparc.Configuration) -> None:
 def test_search_files(
     tmp_file: Path, cfg: osparc.Configuration, use_checksum: bool, use_id: bool
 ) -> None:
-    checksum: str = compute_sha256(tmp_file)
-    assert checksum == _hash_file(tmp_file), "Could not compute correct checksum"
+    checksum: str = _hash_file(tmp_file)
     results: osparc.PaginationGenerator
     with osparc.ApiClient(configuration=cfg) as api_client:
         files_api: osparc.FilesApi = osparc.FilesApi(api_client=api_client)


### PR DESCRIPTION
<!-- Common title prefixes/annotations:
PREFIX:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  ♻️     Refactor code.
  🚑️    Critical hotfix.
  ⚗️     Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🗑️    Deprecate code that needs to be cleaned up.
  ⚰️     Remove dead code.
  🔥    Remove code or files.
  🔨    Add or update development scripts.

or from https://gitmoji.dev/
-->

## What do these changes do?
Fix client e2e portal tests. The following are the changes:
- Don't fail postproccessing job just because one of the test runs fail. This confuses people. Instead the postprocessing job only fails if something in the postprocessing fails.
- Allow for more exitcodes from pytest to ensure tests are reported as failed when tests are interrupted.
- Ensure generated html table is compatible with above changes
<!-- Explain REVIEWERS what is this PR about -->


## Related issue/s

<!-- Enumerate REVIEWERS other issues

e.g.

- #26 : node_ports should have retry policies when upload/download fails  (FIXED)
- ITISFoundation/osparc-issues#304: (Part 2) Prep2Go: creating features to support complex S4L scripts (IMPLEMENTED)

-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->
