### PR TITLE
📝 Expanding doc to easier find doc for api versions

### DIFF
--- a/.github/workflows/publish-python-client.yml
+++ b/.github/workflows/publish-python-client.yml
@@ -3,13 +3,6 @@ on:
   workflow_dispatch:
   push:
   pull_request:
-    types:
-      - opened
-      - reopened
-      - ready_for_review
-      - review_requested
-      - edited
-      - synchronize
 jobs:
   build-n-publish:
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ docs: ## generate docs
 http-doc: docs ## generates and serves doc
 	# starting doc website
 	@echo "Check site on http://127.0.0.1:50001/"
-	python3 -m http.server 50001
+	python3 -m http.server 50001 --bind 127.0.0.1
 
 ## CLEAN -------------------------------------------------------------------------------
 

--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ docs: ## generate docs
 http-doc: docs ## generates and serves doc
 	# starting doc website
 	@echo "Check site on http://127.0.0.1:50001/"
-	python3 -m http.server 50001 --bind 127.0.0.1
+	python3 -m http.server 50001
 
 ## CLEAN -------------------------------------------------------------------------------
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
-<h1 align="center">Osparc-Simcore-Clients</h1>
+<h1 align="center">oSPARC-Simcore-Clients</h1>
 
-To get started using the tools developed in this repository, take a look at the the following links:
-- [Basic tutorial](https://itisfoundation.github.io/osparc-simcore-clients/#/clients/python/artifacts/docs/BasicTutorial)
-- [Documentation](https://itisfoundation.github.io/osparc-simcore-clients)
+To get started using the tools developed in this repository have a look at the
+[Documentation](https://itisfoundation.github.io/osparc-simcore-clients).
 
 For more in depth knowledge concerning the development of the repository, take a look at
 - [Release Notes](https://github.com/ITISFoundation/osparc-simcore-clients/releases)
@@ -14,7 +13,10 @@ For reporting an issue, use our [issue tracker](https://github.com/ITISFoundatio
 
 These notes are intended for people who want to contribute to the development of this repository.
 
-The different clients for the osparc public API are generated using the [openapi-generator](https://github.com/ITISFoundation/openapi-generator)-tool. *The generated files should not be changed manually!* Instead proposed changes should be implemented directly on the [openapi-generator](https://github.com/ITISFoundation/openapi-generator)-repository. See also [templates](https://openapi-generator.tech/docs/templating) and [customization](https://openapi-generator.tech/docs/customization).
+The different clients for the oSPARC public API are generated using the [openapi-generator](https://github.com/ITISFoundation/openapi-generator)-tool.
+*The generated files should not be changed manually!*
+Instead proposed changes should be implemented directly on the [openapi-generator](https://github.com/ITISFoundation/openapi-generator)-repository.
+See also [templates](https://openapi-generator.tech/docs/templating) and [customization](https://openapi-generator.tech/docs/customization).
 
 ## Workflow
 

--- a/docs/doc_entrypoint.md
+++ b/docs/doc_entrypoint.md
@@ -1,3 +1,16 @@
-<h1 align="center">Osparc-Simcore</h1>
+<h1 align="center">oSPARC-Simcore clients</h1>
 
-[o²S²PARC](https://sparc.science/resources/4LkLiH5s4FV0LVJd3htsvH) is an open, cloud-based platform for the development, execution and sharing of computational models, simulations, and data analysis pipelines, and the presentation of results. This site documents clients for interacting with o²S²PARC programatically. Choose your favorite programming language in the top-right navigation bar and get started.
+[o²S²PARC](https://sparc.science/resources/4LkLiH5s4FV0LVJd3htsvH) is
+an open, cloud-based platform for the development, execution and sharing of
+computational models, simulations, and data analysis pipelines, and the
+presentation of results.
+
+This site documents clients for interacting with o²S²PARC programmatically.
+
+Please first choose the version of the client you are using:
+  * Python API:
+    * [v0.5.0](clients/python/docs/v0.5.0/README.md)
+    * [v0.6.0](clients/python/docs/v0.6.0/README.md)
+
+We're committed to continually expanding and refining our platform.
+Stay tuned for future updates and additional API client offerings.

--- a/index.html
+++ b/index.html
@@ -3,10 +3,10 @@
 
 <head>
   <meta charset="UTF-8">
-  <title>osparc API client</title>
+  <title>oSPARC API clients</title>
   <link rel="icon" href="_media/favicon.png">
   <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
-  <meta name="description" content="A python client SDK for osparc API">
+  <meta name="description" content="A Python client SDK for oSPARC API">
   <meta name="viewport"
     content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
   <link rel="stylesheet" href="//cdn.jsdelivr.net/npm/docsify/lib/themes/vue.css" title="vue"  disabled>
@@ -25,7 +25,7 @@
         '/': 'docs/doc_entrypoint.md',
       },
       maxLevel: 2,
-      name: 'osparc API client',
+      name: 'oSPARC API clients',
       repo: 'https://github.com/ITISFoundation/osparc-simcore-clients.git',
       relativePath: false,
       // copy-code


### PR DESCRIPTION
## What do these changes do?

Remove direct tutorial link from main readme, since it doesn't work.
Mention direct links to API versions in doc.

## Related issue/s

- #76 

## How to test

Look at new doc. Screenshot:

![Screenshot 2023-10-19 at 10 48 05](https://github.com/ITISFoundation/osparc-simcore-clients/assets/3098670/63c54051-06de-497f-a2ca-bd4427fc6963)

