### PR TITLE
🐛 fixes bad auth in e2e

### DIFF
--- a/clients/python/test/e2e/ci/e2e/e2e/preprocess.py
+++ b/clients/python/test/e2e/ci/e2e/e2e/preprocess.py
@@ -50,8 +50,8 @@ def generate_ini(
 
     envs: List[str] = []
     envs.append(f"OSPARC_API_HOST={urlparse(server_cfg.host).geturl()}")
-    envs.append(f"OSPARC_API_KEY={server_cfg.key}")
-    envs.append(f"OSPARC_API_SECRET={server_cfg.secret}")
+    envs.append(f"OSPARC_API_KEY={server_cfg.key.get_secret_value()}")
+    envs.append(f"OSPARC_API_SECRET={server_cfg.secret.get_secret_value()}")
     envs.append(
         f"OSPARC_DEV_FEATURES_ENABLED=" f"{1 if client_cfg.dev_features else 0}"
     )


### PR DESCRIPTION
<!-- Common title prefixes/annotations:
PREFIX:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  ♻️     Refactor code.
  🚑️    Critical hotfix.
  ⚗️     Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🗑️    Deprecate code that needs to be cleaned up.
  ⚰️     Remove dead code.
  🔥    Remove code or files.
  🔨    Add or update development scripts.

or from https://gitmoji.dev/
-->

## What do these changes do?

After adding `SecretStr` in #162 I introduced a bug in the auth for the e2e.

## Related issue/s

@elisabettai pointed out that the e2e was failing due to authentication and this is probably the reason

<img width="873" alt="image" src="https://github.com/ITISFoundation/osparc-simcore-clients/assets/32402063/3aa49dca-37b4-420f-8ed5-1217960f0376">



## How to test

e2e should run now
