### PR TITLE
🐛 fixes e2e tests: missing fixture

### DIFF
--- a/clients/python/test/e2e/test_notebooks.py
+++ b/clients/python/test/e2e/test_notebooks.py
@@ -15,19 +15,50 @@ import pytest
 from packaging.version import Version
 
 _NOTEBOOK_EXECUTION_TIMEOUT_SECONDS: Final[int] = 60 * 20  # 20min
-docs_dir: Path = Path(__file__).parent.parent.parent / "docs"
-all_notebooks: List[Path] = list(docs_dir.rglob("*.ipynb"))
-min_version_reqs: Dict[str, Version] = {
+_docs_dir: Path = Path(__file__).parent.parent.parent / "docs"
+
+all_notebooks: List[Path] = list(_docs_dir.rglob("*.ipynb"))
+
+MIN_VERSION_REQS: Dict[str, Version] = {
     "BasicTutorial_v0.5.0.ipynb": Version("0.5.0"),
     "BasicTutorial_v0.6.0.ipynb": Version("0.6.0"),
 }
+
+
+def _papermill_execute_notebook(
+    tmp_path: Path, notebook: Path, parameters: dict[str, Any]
+) -> Path:
+    assert (
+        notebook.is_file()
+    ), f"{notebook.name} is not a file (full path: {notebook.resolve()})"
+
+    if min_version := MIN_VERSION_REQS.get(notebook.name):
+        if Version(osparc.__version__) < min_version:
+            pytest.skip(
+                f"Skipping {notebook.name} because "
+                f"{osparc.__version__=} < {min_version=}"
+            )
+
+    tmp_nb = tmp_path / notebook.name
+    shutil.copy(notebook, tmp_nb)
+    assert tmp_nb.is_file(), "Did not succeed in copying notebook"
+    output: Path = tmp_path / (tmp_nb.stem + "_output.ipynb")
+
+    pm.execute_notebook(
+        input_path=tmp_nb,
+        output_path=output,
+        kernel_name="python3",
+        parameters=parameters,
+        execution_timeout=_NOTEBOOK_EXECUTION_TIMEOUT_SECONDS,
+    )
+    return output
 
 
 def test_notebook_config(tmp_path: Path):
     """Checks the jupyter environment is configured correctly"""
     config_test_nb: Path = Path(__file__).parent / "config_test.ipynb"
     assert config_test_nb.is_file()
-    test_run_notebooks(
+    _papermill_execute_notebook(
         tmp_path,
         config_test_nb,
         {
@@ -36,8 +67,8 @@ def test_notebook_config(tmp_path: Path):
             "expected_osparc_file": osparc.__file__,
         },
     )
-    assert len(all_notebooks) > 0, f"Did not find any notebooks in {docs_dir}"
-    min_keys: set = set(min_version_reqs.keys())
+    assert len(all_notebooks) > 0, f"Did not find any notebooks in {_docs_dir}"
+    min_keys: set = set(MIN_VERSION_REQS.keys())
     notebook_names: set = set(pth.name for pth in all_notebooks)
     msg: str = (
         f"Must specify max version for: {notebook_names-min_keys}."
@@ -49,23 +80,9 @@ def test_notebook_config(tmp_path: Path):
 @pytest.mark.parametrize("notebook", all_notebooks, ids=lambda nb: nb.name)
 def test_run_notebooks(tmp_path: Path, notebook: Path):
     """Run all notebooks in the documentation"""
-    assert (
-        notebook.is_file()
-    ), f"{notebook.name} is not a file (full path: {notebook.resolve()})"
-    if min_version := min_version_reqs.get(notebook.name):
-        if Version(osparc.__version__) < min_version:
-            pytest.skip(
-                f"Skipping {notebook.name} because "
-                f"{osparc.__version__=} < {min_version=}"
-            )
-    tmp_nb = tmp_path / notebook.name
-    shutil.copy(notebook, tmp_nb)
-    assert tmp_nb.is_file(), "Did not succeed in copying notebook"
-    output: Path = tmp_path / (tmp_nb.stem + "_output.ipynb")
-    pm.execute_notebook(
-        input_path=tmp_nb,
-        output_path=output,
-        kernel_name="python3",
-        parameters={}, # NOTE: these notebooks for the moments have not parameters
-        execution_timeout=_NOTEBOOK_EXECUTION_TIMEOUT_SECONDS,
+
+    _papermill_execute_notebook(
+        tmp_path=tmp_path,
+        notebook=notebook,
+        parameters={},  # NOTE: for the moment these notebooks have no parameters
     )

--- a/clients/python/test/e2e/test_notebooks.py
+++ b/clients/python/test/e2e/test_notebooks.py
@@ -47,7 +47,7 @@ def test_notebook_config(tmp_path: Path):
 
 
 @pytest.mark.parametrize("notebook", all_notebooks, ids=lambda nb: nb.name)
-def test_run_notebooks(tmp_path: Path, notebook: Path, params: dict[str, Any]):
+def test_run_notebooks(tmp_path: Path, notebook: Path):
     """Run all notebooks in the documentation"""
     assert (
         notebook.is_file()
@@ -66,6 +66,6 @@ def test_run_notebooks(tmp_path: Path, notebook: Path, params: dict[str, Any]):
         input_path=tmp_nb,
         output_path=output,
         kernel_name="python3",
-        parameters=params or {},
+        parameters={}, # NOTE: these notebooks for the moments have not parameters
         execution_timeout=_NOTEBOOK_EXECUTION_TIMEOUT_SECONDS,
     )


### PR DESCRIPTION
<!-- Common title prefixes/annotations:
PREFIX:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  ♻️     Refactor code.
  🚑️    Critical hotfix.
  ⚗️     Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🗑️    Deprecate code that needs to be cleaned up.
  ⚰️     Remove dead code.
  🔥    Remove code or files.
  🔨    Add or update development scripts.

or from https://gitmoji.dev/
-->

## What do these changes do?

If there is not fixture defined, then it is better not to add it. Before we had
```python
def test_it( some_fixture: dict | None = None):
    ... 
    res = using(some_fixture)
   ...
```
but IMO it is better to just have

```python
def test_it():
   ...
   res = using(None)

```

At first sight, I do not see an advantage in having an undefined fixture in the test parameters. 


## Related issue/s
Fixes e2e
```cmd
file /builds/oSparc/e2e-portal-testing/osparc-simcore-clients/clients/python/test/e2e/test_notebooks.py, line 49
  @pytest.mark.parametrize("notebook", all_notebooks, ids=lambda nb: nb.name)
  def test_run_notebooks(tmp_path: Path, notebook: Path, params: dict[str, Any]):
E       fixture 'params' not found
>       available fixtures: _session_event_loop, anyio_backend, anyio_backend_name, anyio_backend_options, api_client, async_client, cache, capfd, capfdbinary, caplog, capsys, capsysbinary, configuration, doctest_namespace, event_loop, event_loop_policy, extra, extras, file_with_number, include_metadata_in_junit_xml, metadata, monkeypatch, pytestconfig, record_property, record_testsuite_property, record_xml_attribute, recwarn, sleeper, sleeper_study_id, test_notebooks.py::<event_loop>, tmp_file, tmp_path, tmp_path_factory, tmpdir, tmpdir_factory, unused_tcp_port, unused_tcp_port_factory, unused_udp_port, unused_udp_port_factory
>       use 'pytest --fixtures [testpath]' for help on them.

/builds/oSparc/e2e-portal-testing/osparc-simcore-clients/clients/python/test/e2e/test_notebooks.py:49
```

## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## For internal developers

<!--
Make sure to:
- Add the PR to the relevant milestone
- Assign the PR to the relevant person (probably yourself)
- Attach the appropriate label(s) to the PR, like 'documentation', 'bug', etc.
-->
