### PR TITLE
🔨 Fix capture osparc variables

### DIFF
--- a/clients/python/client/osparc/_models.py
+++ b/clients/python/client/osparc/_models.py
@@ -1,7 +1,7 @@
 from typing import Optional
 from uuid import UUID
 
-from pydantic import AnyHttpUrl, Field, field_validator
+from pydantic import AliasChoices, AnyHttpUrl, Field, field_validator
 from pydantic_settings import BaseSettings
 
 
@@ -29,6 +29,7 @@ class ConfigurationModel(BaseSettings):
 
     OSPARC_API_HOST: AnyHttpUrl = Field(
         default=...,
+        validation_alias=AliasChoices("OSPARC_API_BASE_URL", "OSPARC_API_HOST"),
         description="OSPARC api url",
         examples=["https://api.osparc-master.speag.com/"],
     )

--- a/clients/python/client/osparc/_models.py
+++ b/clients/python/client/osparc/_models.py
@@ -27,6 +27,7 @@ class ParentProjectInfo(BaseSettings):
 class ConfigurationModel(BaseSettings):
     """Model for capturing env vars which should go into the Configuration"""
 
+    # Service side: https://github.com/ITISFoundation/osparc-simcore/pull/5966
     OSPARC_API_HOST: AnyHttpUrl = Field(
         default=...,
         validation_alias=AliasChoices("OSPARC_API_BASE_URL", "OSPARC_API_HOST"),

--- a/clients/python/test/test_osparc/test_apis.py
+++ b/clients/python/test/test_osparc/test_apis.py
@@ -70,29 +70,46 @@ def test_create_jobs_parent_headers(
 @pytest.mark.parametrize(
     "OSPARC_API_HOST", ["https://api.foo.com", "https://api.bar.com/", None]
 )
+@pytest.mark.parametrize(
+    "OSPARC_API_BASE_URL", ["https://api.sdkjbf.com", "https://api.alskjd.com/", None]
+)
 @pytest.mark.parametrize("OSPARC_API_KEY", ["key", None])
 @pytest.mark.parametrize("OSPARC_API_SECRET", ["secret", None])
 def test_api_client_constructor(
     monkeypatch: pytest.MonkeyPatch,
     OSPARC_API_HOST: Optional[str],
+    OSPARC_API_BASE_URL: Optional[str],
     OSPARC_API_KEY: Optional[str],
     OSPARC_API_SECRET: Optional[str],
 ):
     with monkeypatch.context() as patch:
         patch.delenv("OSPARC_API_HOST", raising=False)
+        patch.delenv("OSPARC_API_BASE_URL", raising=False)
         patch.delenv("OSPARC_API_KEY", raising=False)
         patch.delenv("OSPARC_API_SECRET", raising=False)
 
         if OSPARC_API_HOST is not None:
             patch.setenv("OSPARC_API_HOST", OSPARC_API_HOST)
+        if OSPARC_API_BASE_URL is not None:
+            patch.setenv("OSPARC_API_BASE_URL", OSPARC_API_BASE_URL)
         if OSPARC_API_KEY is not None:
             patch.setenv("OSPARC_API_KEY", OSPARC_API_KEY)
         if OSPARC_API_SECRET is not None:
             patch.setenv("OSPARC_API_SECRET", OSPARC_API_SECRET)
 
-        if OSPARC_API_HOST and OSPARC_API_KEY and OSPARC_API_SECRET:
+        if (
+            (OSPARC_API_HOST or OSPARC_API_BASE_URL)
+            and OSPARC_API_KEY
+            and OSPARC_API_SECRET
+        ):
             api = ApiClient()
-            assert api.configuration.host == OSPARC_API_HOST.rstrip("/")
+            # if OSPARC_API_BASE_URL and OSPARC_API_HOST are both
+            # in env, the former has preference
+            if OSPARC_API_BASE_URL is not None:
+                assert api.configuration.host == OSPARC_API_BASE_URL.rstrip("/")
+            elif OSPARC_API_HOST is not None:
+                assert api.configuration.host == OSPARC_API_HOST.rstrip("/")
+
             assert api.configuration.username == OSPARC_API_KEY
             assert api.configuration.password == OSPARC_API_SECRET
 


### PR DESCRIPTION
<!-- Common title prefixes/annotations:
PREFIX:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  ♻️     Refactor code.
  🚑️    Critical hotfix.
  ⚗️     Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🗑️    Deprecate code that needs to be cleaned up.
  ⚰️     Remove dead code.
  🔥    Remove code or files.
  🔨    Add or update development scripts.

or from https://gitmoji.dev/
-->

## What do these changes do?

<!-- Explain REVIEWERS what is this PR about -->
- Ensure osparc variables can also be captured when the host is called `OSPARC_API_BASE_URL`.

## Related issue/s

<!-- Enumerate REVIEWERS other issues

e.g.

- #26 : node_ports should have retry policies when upload/download fails  (FIXED)
- ITISFoundation/osparc-issues#304: (Part 2) Prep2Go: creating features to support complex S4L scripts (IMPLEMENTED)

-->
- https://github.com/ITISFoundation/osparc-simcore/pull/5966

## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## For internal developers

<!--
Make sure to:
- Add the PR to the relevant milestone
- Assign the PR to the relevant person (probably yourself)
- Attach the appropriate label(s) to the PR, like 'documentation', 'bug', etc.
-->
