### PR TITLE
🐛 Fix e2e tests compatibility

### DIFF
--- a/clients/python/test/e2e/conftest.py
+++ b/clients/python/test/e2e/conftest.py
@@ -15,6 +15,7 @@ import osparc
 import pytest
 from httpx import AsyncClient, BasicAuth
 from numpy import random
+from packaging.version import Version
 from pydantic import ByteSize
 
 try:
@@ -101,12 +102,12 @@ def api_client() -> Iterable[osparc.ApiClient]:
 
 @pytest.fixture
 def async_client() -> Iterable[AsyncClient]:
-    try:
+    if Version(osparc.__version__) >= Version("8.0.0"):
         configuration = ConfigurationModel()
         host = configuration.OSPARC_API_HOST.rstrip("/")
         username = configuration.OSPARC_API_KEY
         password = configuration.OSPARC_API_SECRET
-    except NameError:
+    else:
         host = os.environ.get("OSPARC_API_HOST")
         username = os.environ.get("OSPARC_API_KEY")
         password = os.environ.get("OSPARC_API_SECRET")

--- a/clients/python/test/e2e/conftest.py
+++ b/clients/python/test/e2e/conftest.py
@@ -15,8 +15,13 @@ import osparc
 import pytest
 from httpx import AsyncClient, BasicAuth
 from numpy import random
-from osparc._models import ConfigurationModel
 from pydantic import ByteSize
+
+try:
+    from osparc._models import ConfigurationModel
+except ImportError:
+    pass
+
 
 _KB: ByteSize = ByteSize(1024)  # in bytes
 _MB: ByteSize = ByteSize(_KB * 1024)  # in bytes
@@ -96,12 +101,21 @@ def api_client() -> Iterable[osparc.ApiClient]:
 
 @pytest.fixture
 def async_client() -> Iterable[AsyncClient]:
-    configuration = ConfigurationModel()
+    try:
+        configuration = ConfigurationModel()
+        host = configuration.OSPARC_API_HOST.rstrip("/")
+        username = configuration.OSPARC_API_KEY
+        password = configuration.OSPARC_API_SECRET
+    except NameError:
+        host = os.environ.get("OSPARC_API_HOST")
+        username = os.environ.get("OSPARC_API_KEY")
+        password = os.environ.get("OSPARC_API_SECRET")
+        assert host and username and password
     yield AsyncClient(
-        base_url=f"{configuration.OSPARC_API_HOST}".rstrip("/"),
+        base_url=host,
         auth=BasicAuth(
-            username=configuration.OSPARC_API_KEY,
-            password=configuration.OSPARC_API_SECRET,
+            username=username,
+            password=password,
         ),
     )  # type: ignore
 


### PR DESCRIPTION
<!-- Common title prefixes/annotations:
PREFIX:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  ♻️     Refactor code.
  🚑️    Critical hotfix.
  ⚗️     Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🗑️    Deprecate code that needs to be cleaned up.
  ⚰️     Remove dead code.
  🔥    Remove code or files.
  🔨    Add or update development scripts.

or from https://gitmoji.dev/
-->

## What do these changes do?

<!-- Explain REVIEWERS what is this PR about -->
- The latest changes to the e2e tests were not compatible with client version 0.5.0, hence the tests fail for that client version.
- This fixes the incompatibility in the tests.

## Related issue/s

<!-- Enumerate REVIEWERS other issues

e.g.

- #26 : node_ports should have retry policies when upload/download fails  (FIXED)
- ITISFoundation/osparc-issues#304: (Part 2) Prep2Go: creating features to support complex S4L scripts (IMPLEMENTED)

-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## For internal developers

<!--
Make sure to:
- Add the PR to the relevant milestone
- Assign the PR to the relevant person (probably yourself)
- Attach the appropriate label(s) to the PR, like 'documentation', 'bug', etc.
-->
