### PR TITLE
🎨 Change to debug level logging

### DIFF
--- a/clients/python/client/osparc/_files_api.py
+++ b/clients/python/client/osparc/_files_api.py
@@ -125,11 +125,11 @@ class FilesApi(_FilesApi):
             configuration=self.api_client.configuration, timeout=timeout_seconds
         ) as session:
             with logging_redirect_tqdm():
-                _logger.info("Uploading %s in %i chunk(s)", file.name, n_urls)
+                _logger.debug("Uploading %s in %i chunk(s)", file.name, n_urls)
                 async for chunck, size in tqdm(
                     file_chunk_generator(file, chunk_size),
                     total=n_urls,
-                    disable=(not _logger.isEnabledFor(logging.INFO)),
+                    disable=(not _logger.isEnabledFor(logging.DEBUG)),
                 ):
                     index, url = next(url_iter)
                     uploaded_parts.append(
@@ -155,7 +155,7 @@ class FilesApi(_FilesApi):
                 auth=self._auth,
                 timeout=timeout_seconds,
             ) as session:
-                _logger.info(
+                _logger.debug(
                     (
                         "Completing upload of %s "
                         "(this might take a couple of minutes)..."
@@ -165,7 +165,7 @@ class FilesApi(_FilesApi):
                 server_file: File = await self._complete_multipart_upload(
                     session, links.complete_upload, client_file, uploaded_parts
                 )
-                _logger.info("File upload complete: %s", file.name)
+                _logger.debug("File upload complete: %s", file.name)
                 return server_file
 
     async def _complete_multipart_upload(

--- a/clients/python/client/osparc/_studies_api.py
+++ b/clients/python/client/osparc/_studies_api.py
@@ -124,13 +124,13 @@ class StudiesApi(_StudiesApi):
                 asyncio.create_task(_download(link.node_name, link.download_link))
                 for link in log_links
             ]
-            _logger.info(
+            _logger.debug(
                 "Downloading log files for study_id=%s and job_id=%s...",
                 study_id,
                 job_id,
             )
             await tqdm_asyncio.gather(
-                *tasks, disable=(not _logger.isEnabledFor(logging.INFO))
+                *tasks, disable=(not _logger.isEnabledFor(logging.DEBUG))
             )
 
         return folder


### PR DESCRIPTION
<!-- Common title prefixes/annotations:
PREFIX:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  ♻️     Refactor code.
  🚑️    Critical hotfix.
  ⚗️     Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🗑️    Deprecate code that needs to be cleaned up.
  ⚰️     Remove dead code.
  🔥    Remove code or files.
  🔨    Add or update development scripts.

or from https://gitmoji.dev/
-->

## What do these changes do?

<!-- Explain REVIEWERS what is this PR about -->
- Change logging in client to `DEBUG` level. Main motivation is to not "pollute" the logs of the metamodeling map service too much.

## Related issue/s

<!-- Enumerate REVIEWERS other issues

e.g.

- #26 : node_ports should have retry policies when upload/download fails  (FIXED)
- ITISFoundation/osparc-issues#304: (Part 2) Prep2Go: creating features to support complex S4L scripts (IMPLEMENTED)

-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## For internal developers

<!--
Make sure to:
- Add the PR to the relevant milestone
- Assign the PR to the relevant person (probably yourself)
- Attach the appropriate label(s) to the PR, like 'documentation', 'bug', etc.
-->
