### PR TITLE
fixing e2e tests

### DIFF
--- a/clients/python/Makefile
+++ b/clients/python/Makefile
@@ -112,7 +112,7 @@ install-unit-test: _check_venv_active ## install packages for unit testing clien
 	uv pip install -r $(CLIENTS_PYTHON_DIR)/requirements/unit-test.txt
 
 .PHONY: install-e2e-test
-install-e2e-test: _check_venv_active ## install packages for e2e testing client
+install-e2e-test: _check_venv_active ## install packages for e2e testing client [e2e]
 	uv pip install -r $(CLIENTS_PYTHON_DIR)/requirements/e2e-test.txt
 
 .PHONY: install-doc

--- a/clients/python/test/e2e/_utils.py
+++ b/clients/python/test/e2e/_utils.py
@@ -17,7 +17,7 @@ def osparc_dev_features_enabled() -> bool:
 
 def repo_version() -> Version:
     subprocess.run(
-        "make client/VERSION", cwd=_clients_python_dir.resolve(), shell=True
+        "make VERSION", cwd=_clients_python_dir.resolve(), shell=True
     ).check_returncode()
     version_file: Path = Path(_clients_python_dir / "VERSION")
     assert version_file.is_file()


### PR DESCRIPTION
<!-- Common title prefixes/annotations:
PREFIX:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  ♻️     Refactor code.
  🚑️    Critical hotfix.
  ⚗️     Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🗑️    Deprecate code that needs to be cleaned up.
  ⚰️     Remove dead code.
  🔥    Remove code or files.
  🔨    Add or update development scripts.

or from https://gitmoji.dev/
-->

## What do these changes do?

IMO this is a good example of a faulty design: using `make` recipes in the unit testing code. `makefile` are close to the user and used as a tool that collect CLI options for the upper-most level user.  I would argue, base on [POLA](https://en.wikipedia.org/wiki/Principle_of_least_astonishment) , that `makefile`  can call `pytest` but **not the other way around**


## Related issue/s

- failing e2e tests


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## For internal developers

<!--
Make sure to:
- Add the PR to the relevant milestone
- Assign the PR to the relevant person (probably yourself)
- Attach the appropriate label(s) to the PR, like 'documentation', 'bug', etc.
-->
