### PR TITLE
🐛 Dont fail when cleaning up

### DIFF
--- a/clients/python/test/e2e/conftest.py
+++ b/clients/python/test/e2e/conftest.py
@@ -30,6 +30,8 @@ _KB: ByteSize = ByteSize(1024)  # in bytes
 _MB: ByteSize = ByteSize(_KB * 1024)  # in bytes
 _GB: ByteSize = ByteSize(_MB * 1024)  # in bytes
 
+_logger = logging.getLogger(__name__)
+
 # Dictionary to store start times of tests
 _test_start_times = {}
 
@@ -175,7 +177,10 @@ def large_server_file(
     try:
         files_api.delete_file(uploaded_file.id)
     except osparc.ApiException:
-        pass
+        _logger.warning(
+            f"Could not delete file on server in {file_with_number.__name__}",
+            exc_info=True,
+        )
 
 
 @pytest.fixture
@@ -212,4 +217,7 @@ def file_with_number(
     try:
         files_api.delete_file(server_file.id)
     except osparc.ApiException:
-        pass
+        _logger.warning(
+            f"Could not delete file on server in {file_with_number.__name__}",
+            exc_info=True,
+        )

--- a/clients/python/test/e2e/conftest.py
+++ b/clients/python/test/e2e/conftest.py
@@ -172,7 +172,10 @@ def large_server_file(
         upload_ram_usage=max(ram_statistics) - min(ram_statistics),
     )
 
-    files_api.delete_file(uploaded_file.id)
+    try:
+        files_api.delete_file(uploaded_file.id)
+    except osparc.ApiException:
+        pass
 
 
 @pytest.fixture
@@ -206,4 +209,7 @@ def file_with_number(
     server_file = files_api.upload_file(file)
     yield server_file
 
-    files_api.delete_file(server_file.id)
+    try:
+        files_api.delete_file(server_file.id)
+    except osparc.ApiException:
+        pass

--- a/clients/python/test/e2e/test_files_api.py
+++ b/clients/python/test/e2e/test_files_api.py
@@ -8,7 +8,6 @@ import hashlib
 from pathlib import Path
 
 import osparc
-from osparc._utils import PaginationIterable
 import pytest
 from memory_profiler import memory_usage
 from typing import Final, Callable
@@ -90,9 +89,7 @@ def test_search_files(
     use_id: bool,
     faker: Faker,
 ) -> None:
-    results: PaginationIterable = files_api._search_files(
-        sha256_checksum=f"{faker.sha256()}"
-    )
+    results = files_api._search_files(sha256_checksum=f"{faker.sha256()}")
     assert len(results) == 0, "Found file which shouldn't be there"
 
     results = files_api._search_files(


### PR DESCRIPTION
<!-- Common title prefixes/annotations:
PREFIX:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  ♻️     Refactor code.
  🚑️    Critical hotfix.
  ⚗️     Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🗑️    Deprecate code that needs to be cleaned up.
  ⚰️     Remove dead code.
  🔥    Remove code or files.
  🔨    Add or update development scripts.

or from https://gitmoji.dev/
-->

## What do these changes do?
I have observed that our e2e tests sometimes fail when cleaning up, that's not intended
<!-- Explain REVIEWERS what is this PR about -->


## Related issue/s

<!-- Enumerate REVIEWERS other issues

e.g.

- #26 : node_ports should have retry policies when upload/download fails  (FIXED)
- ITISFoundation/osparc-issues#304: (Part 2) Prep2Go: creating features to support complex S4L scripts (IMPLEMENTED)

-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## For internal developers

<!--
Make sure to:
- Add the PR to the relevant milestone
- Assign the PR to the relevant person (probably yourself)
- Attach the appropriate label(s) to the PR, like 'documentation', 'bug', etc.
-->
