### PR TITLE
🐛 Fix `osparc` wrapper issues due to `openapi.json` update

### DIFF
--- a/.github/workflows/build-python-client.yml
+++ b/.github/workflows/build-python-client.yml
@@ -65,7 +65,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.8, 3.9, 3.10.14]
+        python-version: [3.9, 3.10.14, 3.11]
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}

--- a/clients/python/src/osparc/_api_files_api.py
+++ b/clients/python/src/osparc/_api_files_api.py
@@ -25,6 +25,7 @@ from .models import (
     FileUploadCompletionBody,
     FileUploadData,
     UploadedPart,
+    UserFile,
 )
 from urllib.parse import urljoin
 import aiofiles
@@ -150,11 +151,12 @@ class FilesApi(_FilesApi):
                 # if a file has the same sha256 checksum
                 # and name they are considered equal
                 return file_result
-        client_file: ClientFile = ClientFile(
+        user_file = UserFile(
             filename=file.name,
             filesize=file.stat().st_size,
             sha256_checksum=checksum,
         )
+        client_file = ClientFile(user_file)
         client_upload_schema: ClientFileUploadData = super().get_upload_links(
             client_file=client_file, _request_timeout=timeout_seconds, **kwargs
         )

--- a/clients/python/src/osparc/_api_solvers_api.py
+++ b/clients/python/src/osparc/_api_solvers_api.py
@@ -77,7 +77,7 @@ class SolversApi(_SolversApi):
         """
 
         def _pagination_method():
-            return super(SolversApi, self).get_jobs_page(
+            return super(SolversApi, self).list_jobs_paginated(
                 solver_key=solver_key,
                 version=version,
                 limit=_DEFAULT_PAGINATION_LIMIT,

--- a/clients/python/src/osparc/models.py
+++ b/clients/python/src/osparc/models.py
@@ -59,7 +59,7 @@ from osparc_client.models.user_role_enum import UserRoleEnum as UserRoleEnum
 from osparc_client.models.users_group import UsersGroup as UsersGroup
 from osparc_client.models.validation_error import ValidationError as ValidationError
 from osparc_client.models.wallet_status import WalletStatus as WalletStatus
-
+from osparc_client.models.user_file import UserFile as UserFile
 from ._models import JobInputs as JobInputs
 from ._models import JobOutputs as JobOutputs
 from ._models import JobMetadata as JobMetadata


### PR DESCRIPTION
<!-- Common title prefixes/annotations:
PREFIX:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  ♻️     Refactor code.
  🚑️    Critical hotfix.
  ⚗️     Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🗑️    Deprecate code that needs to be cleaned up.
  ⚰️     Remove dead code.
  🔥    Remove code or files.
  🔨    Add or update development scripts.

or from https://gitmoji.dev/
-->

## What do these changes do?

<!-- Explain REVIEWERS what is this PR about -->
- The many changes to `openapi.json` changed the `osparc_client` caused changes in the `osparc_client`, this corrects the wrappers in `osparc`. I have run the e2e tests locally against inhouse master to check that this fixes the current issues.

## Related issue/s

<!-- Enumerate REVIEWERS other issues

e.g.

- #26 : node_ports should have retry policies when upload/download fails  (FIXED)
- ITISFoundation/osparc-issues#304: (Part 2) Prep2Go: creating features to support complex S4L scripts (IMPLEMENTED)

-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## For internal developers

<!--
Make sure to:
- Add the PR to the relevant milestone
- Assign the PR to the relevant person (probably yourself)
- Attach the appropriate label(s) to the PR, like 'documentation', 'bug', etc.
-->
