### PR TITLE
🐛 Fix tests after StrictStr -> UUID change in latest (dev) version of client

### DIFF
--- a/clients/python/test/e2e/conftest.py
+++ b/clients/python/test/e2e/conftest.py
@@ -200,7 +200,9 @@ def sleeper_study_id(api_client: osparc.ApiClient) -> UUID:
     study_api = osparc.StudiesApi(api_client=api_client)
     for study in study_api.iter_studies():
         if study.title == _test_study_title:
-            return UUID(study.uid)
+            return (
+                study.uid if isinstance(study.uid, UUID) else UUID(study.uid)
+            )  # keep test backwards compatible
     pytest.fail(f"Could not find {_test_study_title} study")
 
 

--- a/clients/python/test/e2e/test_solvers_api.py
+++ b/clients/python/test/e2e/test_solvers_api.py
@@ -10,6 +10,7 @@ import osparc
 from _utils import skip_if_osparc_version
 from httpx import AsyncClient
 from packaging.version import Version
+from uuid import UUID
 
 DEFAULT_TIMEOUT_SECONDS = 10 * 60  # 10 min
 
@@ -80,7 +81,9 @@ async def test_logstreaming(
             log = json.loads(line)
             job_id = log.get("job_id")
             assert job_id
-            assert job_id == job.id
+            assert job_id == (
+                f"{job.id}" if isinstance(job.id, UUID) else job.id
+            )  # keep test backwards compatible
             nloglines += 1
             print("\n".join(log.get("messages")))
             if nloglines > 10:  # dont wait too long


### PR DESCRIPTION
<!-- Common title prefixes/annotations:
PREFIX:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  ♻️     Refactor code.
  🚑️    Critical hotfix.
  ⚗️     Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🗑️    Deprecate code that needs to be cleaned up.
  ⚰️     Remove dead code.
  🔥    Remove code or files.
  🔨    Add or update development scripts.

or from https://gitmoji.dev/
-->

## What do these changes do?
- This PR fixes e2e tests after the latest release (https://github.com/ITISFoundation/osparc-simcore-clients/pull/232) of the dev version of the client.
- WARNING: The need for this PR to make tests pass show that the client has broken backwards compatibility. Hence, for the next proper release we should bump the major version of the client.
<!-- Explain REVIEWERS what is this PR about -->


## Related issue/s

<!-- Enumerate REVIEWERS other issues

e.g.

- #26 : node_ports should have retry policies when upload/download fails  (FIXED)
- ITISFoundation/osparc-issues#304: (Part 2) Prep2Go: creating features to support complex S4L scripts (IMPLEMENTED)

-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## For internal developers

<!--
Make sure to:
- Add the PR to the relevant milestone
- Assign the PR to the relevant person (probably yourself)
- Attach the appropriate label(s) to the PR, like 'documentation', 'bug', etc.
-->
