### PR TITLE
reintroduce missing script

### DIFF
--- a/scripts/is_semantic_version.py
+++ b/scripts/is_semantic_version.py
@@ -1,0 +1,21 @@
+import typer
+from semver.version import Version as V
+
+
+def main(version_string: str, raise_result: bool = True):
+    """
+    Check if a string v is a "pure" semantic version. I.e. v=a.b.c
+    for positive integers a, b and c. We don't allow prerelease info
+    or dev info here.
+    """
+    result: bool = V.is_valid(version_string)
+    if result:
+        v: V = V.parse(version_string)
+        result = v == V(v.major, v.minor, v.patch)
+    if raise_result:
+        raise typer.Exit(code=0 if result else 1)
+    print(result)
+
+
+if __name__ == "__main__":
+    typer.run(main)


### PR DESCRIPTION
This pull request adds a script (which was deleted in https://github.com/ITISFoundation/osparc-simcore-clients/pull/194), `is_semantic_version.py`, which provides a command-line tool to validate whether a given string is a "pure" semantic version (in the format `a.b.c` with positive integers and no prerelease or dev info). The script is still used in the CI and that's why it is reintroduced.

New script for semantic version validation:

* Added `scripts/is_semantic_version.py`, which uses `typer` and `semver` to check if a provided version string matches the strict `a.b.c` format and can be used as a CLI tool.